### PR TITLE
Bugfix/hover selection modes

### DIFF
--- a/JammaLib/src/base/GuiElement.cpp
+++ b/JammaLib/src/base/GuiElement.cpp
@@ -400,6 +400,11 @@ void GuiElement::SetIndex(unsigned int index)
 	_index = index;
 }
 
+unsigned int GuiElement::Index() const
+{
+	return _index;
+}
+
 std::vector<unsigned int> GuiElement::GlobalId()
 {
 	if (nullptr == _parent)
@@ -427,8 +432,11 @@ void GuiElement::AddChild(std::shared_ptr<GuiElement> child)
 
 std::shared_ptr<GuiElement> GuiElement::TryGetChild(unsigned char index)
 {
-	if (index < _children.size())
-		return _children.at(index);
+	for (auto& child : _children)
+	{
+		if (child->Index() == index)
+			return child;
+	}
 
 	return nullptr;
 }

--- a/JammaLib/src/base/GuiElement.h
+++ b/JammaLib/src/base/GuiElement.h
@@ -109,6 +109,7 @@ namespace base
 		virtual void SetPickingFromState(EditMode mode, bool flipState);
 		virtual void SetStateFromPicking(EditMode mode, bool flipState);
 		virtual void SetIndex(unsigned int index);
+		unsigned int Index() const;
 		virtual std::vector<unsigned int> GlobalId();
 		virtual void AddChild(std::shared_ptr<GuiElement> child);
 		virtual std::shared_ptr<GuiElement> TryGetChild(unsigned char index);

--- a/JammaLib/src/engine/Loop.cpp
+++ b/JammaLib/src/engine/Loop.cpp
@@ -467,15 +467,18 @@ void Loop::Play(unsigned long index,
 	unsigned long loopLength,
 	bool continueRecording)
 {
-	auto bufSize = _bufferBank.Length();
+	auto physBufSize = _bufferBank.Length();
 
-	if (0 == bufSize)
+	if (0 == physBufSize)
 	{
 		Reset();
 		return;
 	}
 
-	_playIndex = index >= bufSize ? (bufSize-1) : index;
+	// Clamp against the logical buffer size (loopLength + MaxLoopFadeSamps), not the
+	// physical size at trigger time, due to endRecordSamps tail.
+	auto logicalBufSize = loopLength + constants::MaxLoopFadeSamps;
+	_playIndex = (logicalBufSize > 0 && index >= logicalBufSize) ? (logicalBufSize - 1) : index;
 	_loopLength = loopLength;
 
 	auto isOverdubbing = (STATE_OVERDUBBING == _playState) || (STATE_PUNCHEDIN == _playState);

--- a/JammaLib/src/engine/Loop.cpp
+++ b/JammaLib/src/engine/Loop.cpp
@@ -475,10 +475,12 @@ void Loop::Play(unsigned long index,
 		return;
 	}
 
-	// Clamp against the logical buffer size (loopLength + MaxLoopFadeSamps), not the
-	// physical size at trigger time, due to endRecordSamps tail.
+	// Clamp against the smaller of the logical loop size and the currently
+	// recorded physical size. This prevents reads past the current BufferBank
+	// length while still ignoring any physical tail beyond the logical loop.
 	auto logicalBufSize = loopLength + constants::MaxLoopFadeSamps;
-	_playIndex = (logicalBufSize > 0 && index >= logicalBufSize) ? (logicalBufSize - 1) : index;
+	auto effectiveBufSize = std::min(logicalBufSize, physBufSize);
+	_playIndex = (effectiveBufSize > 0 && index >= effectiveBufSize) ? (effectiveBufSize - 1) : index;
 	_loopLength = loopLength;
 
 	auto isOverdubbing = (STATE_OVERDUBBING == _playState) || (STATE_PUNCHEDIN == _playState);

--- a/JammaLib/src/engine/LoopModel.cpp
+++ b/JammaLib/src/engine/LoopModel.cpp
@@ -41,7 +41,9 @@ void LoopModel::Draw3d(DrawContext& ctx,
 	{
 	case STATE_PICKING:
 		idVec = GlobalId();
-		idVec.resize(2);
+		idVec.resize(3);
+		for (auto& idPart : idVec)
+			idPart += 1;
 		id = utils::VecToId(idVec);
 
 		glCtx.SetUniform("ObjectId", id);

--- a/JammaLib/src/engine/LoopTake.cpp
+++ b/JammaLib/src/engine/LoopTake.cpp
@@ -239,6 +239,13 @@ void LoopTake::EndMultiWrite(unsigned int numSamps,
 	}
 }
 
+void LoopTake::SetSelectDepth(base::SelectDepth depth)
+{
+	Jammable::SetSelectDepth(depth);
+	if (_guiRack)
+		_guiRack->SetVisible(depth == base::SelectDepth::DEPTH_LOOPTAKE);
+}
+
 ActionResult LoopTake::OnAction(GuiAction action)
 {
 	auto res = GuiElement::OnAction(action);
@@ -647,6 +654,12 @@ void LoopTake::PunchOut()
 	}
 }
 
+void LoopTake::SetRackVisibility(bool visible)
+{
+	// Set the visibility of the LoopTake rack
+	_guiRack->SetVisible(visible);
+}
+
 unsigned int LoopTake::_CalcLoopHeight(unsigned int takeHeight, unsigned int numLoops)
 {
 	if (0 == numLoops)
@@ -700,6 +713,10 @@ std::vector<JobAction> LoopTake::_CommitChanges()
 			if (_children.end() != child)
 				_children.erase(child);
 		}
+
+		// Re-index children so _index values are consistent with TryGetChild lookups
+		for (unsigned int i = 0; i < _children.size(); i++)
+			_children[i]->SetIndex(i);
 
 		_loops = _backLoops; // TODO: Undo?
 		_audioBuffers = _backAudioBuffers;

--- a/JammaLib/src/engine/LoopTake.h
+++ b/JammaLib/src/engine/LoopTake.h
@@ -104,6 +104,7 @@ namespace engine
 		virtual void EndMultiWrite(unsigned int numSamps,
 			bool updateIndex,
 			Audible::AudioSourceType source) override;
+		virtual void SetSelectDepth(base::SelectDepth depth) override;
 		virtual actions::ActionResult OnAction(actions::GuiAction action) override;
 		virtual actions::ActionResult OnAction(actions::JobAction action) override;
 		virtual bool Select() override;
@@ -134,6 +135,7 @@ namespace engine
 		void Overdub(std::vector<unsigned int> channels, std::string stationName);
 		void PunchIn();
 		void PunchOut();
+		void SetRackVisibility(bool visible);
 
 	protected:
 		static unsigned int _CalcLoopHeight(unsigned int takeHeight, unsigned int numLoops);

--- a/JammaLib/src/engine/Scene.cpp
+++ b/JammaLib/src/engine/Scene.cpp
@@ -42,7 +42,8 @@ Scene::Scene(SceneParams params,
 			1.0),
 		0)),
 	_userConfig(user),
-	_clock(std::make_shared<Timer>())
+	_clock(std::make_shared<Timer>()),
+	_viewMode(VIEW_STATION)
 {
 	GuiLabelParams labelParams;
 	labelParams.String = "Jamma";
@@ -55,6 +56,7 @@ Scene::Scene(SceneParams params,
 	selectorParams.Position = { 10, 2 };
 	selectorParams.Size = params.Size;
 	_selector = std::make_unique<GuiSelector>(selectorParams);
+	_selector->SetSelectDepth(base::DEPTH_STATION);
 
 	GuiRadioParams modeRadioParams;
 	modeRadioParams.Size = { 480, 64 };
@@ -157,6 +159,7 @@ std::optional<std::shared_ptr<Scene>> Scene::FromFile(SceneParams sceneParams,
 	}
 
 	scene->_SetQuantisation(jamStruct.QuantiseSamps, jamStruct.Quantisation);
+	scene->InitReceivers();
 
 	return scene;
 }
@@ -431,8 +434,11 @@ ActionResult Scene::OnAction(GuiAction action)
 	switch (action.ElementType)
 	{
 		case GuiAction::ACTIONELEMENT_RADIO:
-			_UpdateSelectDepth(action.Index);
-			std::cout << "GuiRadio called" << std::endl;
+			if (auto i = std::get_if<GuiAction::GuiInt>(&action.Data))
+			{
+				_viewMode = (ViewMode)i->Value;
+				_UpdateSelectDepth((unsigned int)_viewMode);
+			}
 			break;
 	}
 
@@ -504,10 +510,19 @@ void Scene::SetHover3d(std::vector<unsigned char> path, Action::Modifiers modifi
 {
 	bool isSelected = false;
 	auto tweakState = base::Tweakable::TweakState::TWEAKSTATE_NONE;
+	std::vector<unsigned char> elementPath;
 
-	path = TrimPath(path, _selector->CurrentSelectDepth());
+	for (auto segment : path)
+	{
+		if (0 == segment)
+			break;
 
-	auto hovering = _ChildFromPath(path);
+		elementPath.push_back(segment - 1);
+	}
+
+	elementPath = TrimPath(elementPath, _selector->CurrentSelectDepth() + 1);
+
+	auto hovering = _ChildFromPath(elementPath);
 	if (nullptr != hovering)
 	{
 		isSelected = hovering->IsSelected();
@@ -516,7 +531,7 @@ void Scene::SetHover3d(std::vector<unsigned char> path, Action::Modifiers modifi
 			tweakState = tweakable->GetTweakState();
 	}
 
-	_selector->UpdateCurrentHover(path,
+	_selector->UpdateCurrentHover(elementPath,
 		modifiers,
 		isSelected,
 		tweakState);
@@ -891,6 +906,12 @@ void Scene::_AddStation(std::shared_ptr<Station> station)
 	station->SetNumAdcChannels(_channelMixer->Source()->NumOutputChannels(Audible::AUDIOSOURCE_ADC));
 	station->SetNumDacChannels(_channelMixer->Sink()->NumInputChannels(Audible::AUDIOSOURCE_LOOPS));
 	station->Init();
+
+	auto selectDepth = (unsigned int)_viewMode;
+	if (selectDepth > (unsigned int)DEPTH_LOOP)
+		selectDepth = (unsigned int)DEPTH_LOOP;
+
+	station->SetSelectDepth((SelectDepth)selectDepth);
 }
 
 void Scene::_SetQuantisation(unsigned int quantiseSamps, Timer::QuantisationType quantisation)
@@ -939,7 +960,10 @@ std::shared_ptr<GuiElement> Scene::_ChildFromPath(std::vector<unsigned char> pat
 
 void Scene::_UpdateSelectDepth(unsigned int depth)
 {
-	auto selectDepth = depth > 0 ? (SelectDepth)(depth - 1) : DEPTH_STATION;
+	if (depth > (unsigned int)DEPTH_LOOP)
+		depth = (unsigned int)DEPTH_LOOP;
+
+	auto selectDepth = (SelectDepth)depth;
 	_selector->SetSelectDepth(selectDepth);
 
 	for (auto& station : _stations)

--- a/JammaLib/src/engine/Scene.h
+++ b/JammaLib/src/engine/Scene.h
@@ -51,6 +51,14 @@ namespace engine
 		public base::ActionReceiver
 	{
 	public:
+		enum ViewMode
+		{
+			VIEW_STATION = 0,
+			VIEW_LOOPTAKE = 1,
+			VIEW_LOOP = 2
+		};
+
+	public:
 		Scene(SceneParams params,
 			io::UserConfig user);
 		~Scene()
@@ -229,5 +237,6 @@ namespace engine
 		std::mutex _audioMutex;
 		io::UserConfig _userConfig;
 		std::shared_ptr<Timer> _clock;
+		ViewMode _viewMode;
 	};
 }

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -243,6 +243,13 @@ void Station::EndMultiWrite(unsigned int numSamps,
 		take->EndMultiWrite(numSamps, updateIndex, source);
 }
 
+void Station::SetSelectDepth(base::SelectDepth depth)
+{
+	Jammable::SetSelectDepth(depth);
+	if (_guiRack)
+		_guiRack->SetVisible(depth == base::SelectDepth::DEPTH_STATION);
+}
+
 ActionResult Station::OnAction(KeyAction action)
 {
 	if (!_isEnabled || !_isVisible)
@@ -602,6 +609,7 @@ void Station::AddTake(std::shared_ptr<LoopTake> take)
 {
 	take->SetupBuffers(_lastBufSize);
 	take->SetNumBusChannels(NumBusChannels());
+	take->SetSelectDepth(CurrentSelectDepth());
 
 	_backLoopTakes.push_back(take);
 
@@ -757,6 +765,18 @@ void Station::OnBounce(unsigned int numSamps, io::UserConfig config)
 	}
 }
 
+void Station::SetRackVisibility(bool showStationRack, bool showLoopTakeRacks)
+{
+	// Set the visibility of the Station (master/channels/router) rack
+	_guiRack->SetVisible(showStationRack);
+
+	// Set the visibility of each LoopTake rack
+	for (auto& take : _loopTakes)
+	{
+		take->SetRackVisibility(showLoopTakeRacks);
+	}
+}
+
 unsigned int Station::_CalcTakeHeight(unsigned int stationHeight, unsigned int numTakes)
 {
 	if (0 == numTakes)
@@ -803,6 +823,10 @@ std::vector<JobAction> Station::_CommitChanges()
 			if (_children.end() != child)
 				_children.erase(child);
 		}
+
+		// Re-index children so _index values are consistent with TryGetChild lookups
+		for (unsigned int i = 0; i < _children.size(); i++)
+			_children[i]->SetIndex(i);
 
 		_loopTakes = _backLoopTakes; // TODO: Undo?
 	}

--- a/JammaLib/src/engine/Station.h
+++ b/JammaLib/src/engine/Station.h
@@ -85,6 +85,7 @@ namespace engine
 		virtual void EndMultiWrite(unsigned int numSamps,
 			bool updateIndex,
 			Audible::AudioSourceType source) override;
+		virtual void SetSelectDepth(base::SelectDepth depth) override;
 		virtual actions::ActionResult OnAction(actions::KeyAction action) override;
 		virtual actions::ActionResult OnAction(actions::GuiAction action) override;
 		virtual actions::ActionResult OnAction(actions::TriggerAction action) override;
@@ -107,6 +108,7 @@ namespace engine
 		void SetNumDacChannels(unsigned int chans);
 		unsigned int NumBusChannels() const;
 		void OnBounce(unsigned int numSamps, io::UserConfig config);
+		void SetRackVisibility(bool showStationRack, bool showLoopTakeRacks);
 
 	protected:
 		static unsigned int _CalcTakeHeight(unsigned int stationHeight, unsigned int numTakes);

--- a/JammaLib/src/gui/GuiRadio.cpp
+++ b/JammaLib/src/gui/GuiRadio.cpp
@@ -24,6 +24,7 @@ GuiRadio::GuiRadio(GuiRadioParams params) :
 		std::cout << "Type: " << typeid(params).name() << std::endl;
 
 		params.Index = count;
+		params.ToggleIndex = count;
 
 		_children.push_back(std::make_shared<GuiToggle>(params));
 

--- a/JammaLib/src/gui/GuiSelector.cpp
+++ b/JammaLib/src/gui/GuiSelector.cpp
@@ -166,13 +166,7 @@ bool GuiSelector::IsHovering(std::vector<unsigned char> path) const
 	if (path.size() < depth)
 		return false;
 
-	for (auto i = 0u; i < depth; i++)
-	{
-		if (path[i] != 0)
-			return true;
-	}
-
-	return false;
+	return !path.empty();
 }
 
 void GuiSelector::StartPaintSelection(SelectMode mode, std::vector<unsigned char> selection)

--- a/test/JammaLib.Tests/src/audio/Loop_Tests.cpp
+++ b/test/JammaLib.Tests/src/audio/Loop_Tests.cpp
@@ -535,6 +535,57 @@ TEST(Loop, Playback_ProducesOutputInOverdubbingRecordingState)
     ASSERT_TRUE(HasNonZeroSample(sink->GetSamples()));
 }
 
+// Regression: when loopLength is quantised upward so that logicalBufSize >
+// physBufSize, Play() must clamp _playIndex to physBufSize-1 rather than
+// logicalBufSize-1 so that subsequent ReadBlock calls never seek into
+// unallocated buffer positions.
+TEST(Loop, Play_IndexClampedToPhysicalBufferWhenQuantisedUp)
+{
+    // physLoopLength samples are actually recorded; quantizedLoopLength is
+    // larger (simulating clock quantisation that added extra samples).
+    const auto physLoopLength = 50ul;
+    const auto quantizedLoopLength = 100ul;  // 50 extra unrecorded samples
+    const auto physBufSize = physLoopLength + static_cast<unsigned long>(constants::MaxLoopFadeSamps);
+    const auto blockSize = 8u;
+
+    auto loop = MakeLoopProbe();
+    loop.Record();
+    WriteData(loop, physLoopLength, 1.0f);   // physBufSize samples in bank
+
+    // Pass an index that is beyond the physical buffer (in the unrecorded tail).
+    const auto indexPastEnd = physBufSize + 5ul;
+    loop.Play(indexPastEnd, quantizedLoopLength, /*continueRecording=*/true);
+
+    // _playIndex must be clamped to the last valid physical index.
+    EXPECT_EQ(physBufSize - 1ul, loop.PlayIndex());
+
+    // ReadBlock must not crash and must produce some output (zero-filled for
+    // unrecorded tail positions is acceptable; non-crash is the key assertion).
+    float tempBuf[constants::MaxBlockSize]{};
+    auto sampsRead = loop.ReadBlock(tempBuf, 0, blockSize);
+    EXPECT_GT(sampsRead, 0u);
+}
+
+// Regression: when the passed index is within the physical buffer but still
+// within the larger quantised logical range, Play() must NOT clamp it.
+TEST(Loop, Play_IndexUnchangedWhenWithinPhysicalBuffer)
+{
+    const auto physLoopLength = 50ul;
+    const auto quantizedLoopLength = 100ul;
+    const auto physBufSize = physLoopLength + static_cast<unsigned long>(constants::MaxLoopFadeSamps);
+
+    auto loop = MakeLoopProbe();
+    loop.Record();
+    WriteData(loop, physLoopLength, 1.0f);
+
+    // Pass an index well within the physical buffer.
+    const auto normalIndex = static_cast<unsigned long>(constants::MaxLoopFadeSamps);
+    loop.Play(normalIndex, quantizedLoopLength, /*continueRecording=*/true);
+
+    // _playIndex must be unchanged.
+    EXPECT_EQ(normalIndex, loop.PlayIndex());
+}
+
 TEST(Loop, WrapXfade_ConstantInputNoGainBump) {
     const auto fadeSamps = constants::DefaultFadeSamps;
     const auto loopLength = 50ul;


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to hierarchical GUI element indexing, selection depth management, and rack visibility in the audio engine's scene graph. The changes enhance the accuracy and consistency of element lookups, improve the handling of selection and hover states, and refine the user interface's responsiveness to view modes.

**Key changes include:**

### Hierarchical Indexing and Child Lookup

- Added an `Index()` getter to `GuiElement` and updated `TryGetChild` to use the element's `_index` value for lookups, ensuring more robust and explicit child retrieval. Also, after structural changes (like commit/undo), child indices are reindexed to maintain consistency. [[1]](diffhunk://#diff-5e5a931a214fa425c5e45a062e0d77741f9e6aec694b5d8f1cc00e111ec40a24R403-R407) [[2]](diffhunk://#diff-5e5a931a214fa425c5e45a062e0d77741f9e6aec694b5d8f1cc00e111ec40a24L430-R439) [[3]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39R717-R720) [[4]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bR827-R830) [[5]](diffhunk://#diff-680d0ddf8e11b449fbc1169a06a9448464dd48a547323cf73795a18ef2074eb6R112)

### Selection Depth and View Mode Management

- Introduced a `ViewMode` enum in `Scene`, and refactored selection depth logic throughout the scene and station hierarchy. The selector and all relevant elements now update their selection depth in response to view mode changes, and selection depth is clamped to valid values. [[1]](diffhunk://#diff-5be142e68be091bda49a45c0a39bc571bd4b00cc20d84bf0702f461c681938b3R53-R60) [[2]](diffhunk://#diff-5be142e68be091bda49a45c0a39bc571bd4b00cc20d84bf0702f461c681938b3R240) [[3]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fL45-R46) [[4]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fR59) [[5]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fL434-R441) [[6]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fR909-R914) [[7]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fL942-R966) [[8]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bR612) [[9]](diffhunk://#diff-72738db198029ce6222b15803fb52f7c08fa0abb10e54e7b0fa9a6fcaffdff1bR88) [[10]](diffhunk://#diff-cb5a800b377fe63dc8d839e7d8d23b99a544a5c77d085dfd1c281b19d01bffe6R107)

### Rack Visibility Control

- Added methods to set the visibility of station and loop take racks based on selection depth and view mode, improving UI feedback and clarity as users navigate the hierarchy. [[1]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bR768-R779) [[2]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39R657-R662) [[3]](diffhunk://#diff-cb5a800b377fe63dc8d839e7d8d23b99a544a5c77d085dfd1c281b19d01bffe6R138) [[4]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39R242-R248) [[5]](diffhunk://#diff-72738db198029ce6222b15803fb52f7c08fa0abb10e54e7b0fa9a6fcaffdff1bR111)

### 3D Picking and Hover State Improvements

- Adjusted object ID generation and hover path handling for 3D picking, including resizing and offsetting ID vectors and trimming hover paths according to selection depth, leading to more accurate GUI interactions. [[1]](diffhunk://#diff-1a1af360b9f8d8afd524fd2cc93f21be24920bc7e80cfddd9122dff2754afa07L44-R46) [[2]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fR513-R525) [[3]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fL519-R534)

### Miscellaneous Fixes and Improvements

- Improved buffer index clamping in `Loop::Play` to avoid out-of-bounds errors, ensured toggle indices are set in `GuiRadio`, and made various initialization and receiver setup adjustments. [[1]](diffhunk://#diff-a8acc7b56a51de11b35099110dcbd833ffa49c82e5c4388beafbc822e0b2388cL470-R481) [[2]](diffhunk://#diff-7ef872ec4b8ff8a81ec17ac5d9e8be6466dcfcc789ef32d2010d5da3aa6443eaR27) [[3]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fR162)

These changes collectively improve the robustness, maintainability, and user experience of the application's GUI and audio engine.