### PR TITLE
Adjust GuiRack and Slider positioning and interaction

### DIFF
--- a/JammaLib/src/engine/LoopTake.cpp
+++ b/JammaLib/src/engine/LoopTake.cpp
@@ -676,7 +676,7 @@ gui::GuiRackParams::RackState LoopTake::GetRackState() const
 
 void LoopTake::CollapseRackToMaster()
 {
-	if (_guiRack && _guiRack->GetRackState() == gui::GuiRackParams::RACK_ROUTER)
+	if (_guiRack && _guiRack->GetRackState() != gui::GuiRackParams::RACK_MASTER)
 		_guiRack->SetRackState(gui::GuiRackParams::RACK_MASTER, true);
 }
 

--- a/JammaLib/src/engine/LoopTake.cpp
+++ b/JammaLib/src/engine/LoopTake.cpp
@@ -680,6 +680,12 @@ void LoopTake::CollapseRackToMaster()
 		_guiRack->SetRackState(gui::GuiRackParams::RACK_MASTER, true);
 }
 
+void LoopTake::CollapseRouterToChannels()
+{
+	if (_guiRack && _guiRack->GetRackState() == gui::GuiRackParams::RACK_ROUTER)
+		_guiRack->SetRackState(gui::GuiRackParams::RACK_CHANNELS, true);
+}
+
 unsigned int LoopTake::_CalcLoopHeight(unsigned int takeHeight, unsigned int numLoops)
 {
 	if (0 == numLoops)

--- a/JammaLib/src/engine/LoopTake.cpp
+++ b/JammaLib/src/engine/LoopTake.cpp
@@ -98,6 +98,9 @@ void LoopTake::SetSize(utils::Size2d size)
 		mixer->SetSize(mixerParams.Size);
 	}
 
+	if (_guiRack)
+		_guiRack->SetSize(size);
+
 	GuiElement::SetSize(size);
 
 	_ArrangeChildren();
@@ -286,6 +289,12 @@ ActionResult LoopTake::OnAction(GuiAction action)
 		{
 			_loops[action.Index - 1]->SetMixerLevel(d->Value);
 		}
+	}
+	else if (std::get_if<GuiAction::GuiInt>(&action.Data))
+	{
+		// Rack state pre-notification from _guiRack — forward to parent receiver (Station).
+		if (_receiver)
+			_receiver->OnAction(action);
 	}
 
 	return res;
@@ -658,6 +667,17 @@ void LoopTake::SetRackVisibility(bool visible)
 {
 	// Set the visibility of the LoopTake rack
 	_guiRack->SetVisible(visible);
+}
+
+gui::GuiRackParams::RackState LoopTake::GetRackState() const
+{
+	return _guiRack ? _guiRack->GetRackState() : gui::GuiRackParams::RACK_MASTER;
+}
+
+void LoopTake::CollapseRackToMaster()
+{
+	if (_guiRack && _guiRack->GetRackState() == gui::GuiRackParams::RACK_ROUTER)
+		_guiRack->SetRackState(gui::GuiRackParams::RACK_MASTER, true);
 }
 
 unsigned int LoopTake::_CalcLoopHeight(unsigned int takeHeight, unsigned int numLoops)

--- a/JammaLib/src/engine/LoopTake.h
+++ b/JammaLib/src/engine/LoopTake.h
@@ -136,6 +136,8 @@ namespace engine
 		void PunchIn();
 		void PunchOut();
 		void SetRackVisibility(bool visible);
+		gui::GuiRackParams::RackState GetRackState() const;
+		void CollapseRackToMaster();
 
 	protected:
 		static unsigned int _CalcLoopHeight(unsigned int takeHeight, unsigned int numLoops);

--- a/JammaLib/src/engine/LoopTake.h
+++ b/JammaLib/src/engine/LoopTake.h
@@ -138,6 +138,7 @@ namespace engine
 		void SetRackVisibility(bool visible);
 		gui::GuiRackParams::RackState GetRackState() const;
 		void CollapseRackToMaster();
+		void CollapseRouterToChannels();
 
 	protected:
 		static unsigned int _CalcLoopHeight(unsigned int takeHeight, unsigned int numLoops);

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -912,6 +912,10 @@ std::optional<std::shared_ptr<LoopTake>> Station::_TryGetTake(std::string id)
 
 void Station::_CollapseOtherTakeRouters()
 {
-	for (auto& take : _loopTakes)
+	auto& takes = (_changesMade && _flipTakeBuffer) ?
+		_backLoopTakes :
+		_loopTakes;
+
+	for (auto& take : takes)
 		take->CollapseRackToMaster();
 }

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -321,7 +321,12 @@ ActionResult Station::OnAction(GuiAction action)
 		if (auto i = std::get_if<GuiAction::GuiInt>(&action.Data))
 		{
 			if (action.Index == gui::GuiRack::RackStateNotificationIndex)
-				_CollapseOtherTakeRouters();
+			{
+				if (i->Value == gui::GuiRackParams::RACK_ROUTER)
+					_CollapseOtherTakeRouters();
+				else if (i->Value == gui::GuiRackParams::RACK_CHANNELS)
+					_CollapseOtherTakeRoutersToChannels();
+			}
 			else
 				SetNumBusChannels(i->Value);
 		}
@@ -918,4 +923,14 @@ void Station::_CollapseOtherTakeRouters()
 
 	for (auto& take : takes)
 		take->CollapseRackToMaster();
+}
+
+void Station::_CollapseOtherTakeRoutersToChannels()
+{
+	auto& takes = (_changesMade && _flipTakeBuffer) ?
+		_backLoopTakes :
+		_loopTakes;
+
+	for (auto& take : takes)
+		take->CollapseRouterToChannels();
 }

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -320,7 +320,10 @@ ActionResult Station::OnAction(GuiAction action)
 	case GuiAction::ACTIONELEMENT_RACK:
 		if (auto i = std::get_if<GuiAction::GuiInt>(&action.Data))
 		{
-			SetNumBusChannels(i->Value);
+			if (action.Index == gui::GuiRack::RackStateNotificationIndex)
+				_CollapseOtherTakeRouters();
+			else
+				SetNumBusChannels(i->Value);
 		}
 		else if (auto chans = std::get_if<GuiAction::GuiConnections>(&action.Data))
 		{
@@ -610,11 +613,8 @@ void Station::AddTake(std::shared_ptr<LoopTake> take)
 	take->SetupBuffers(_lastBufSize);
 	take->SetNumBusChannels(NumBusChannels());
 	take->SetSelectDepth(CurrentSelectDepth());
-
+	take->SetReceiver(ActionReceiver::shared_from_this());
 	_backLoopTakes.push_back(take);
-
-	Init();
-
 	_ArrangeChildren();
 	_flipTakeBuffer = true;
 	_changesMade = true;
@@ -908,4 +908,10 @@ std::optional<std::shared_ptr<LoopTake>> Station::_TryGetTake(std::string id)
 	}
 
 	return std::nullopt;
+}
+
+void Station::_CollapseOtherTakeRouters()
+{
+	for (auto& take : _loopTakes)
+		take->CollapseRackToMaster();
 }

--- a/JammaLib/src/engine/Station.h
+++ b/JammaLib/src/engine/Station.h
@@ -118,6 +118,7 @@ namespace engine
 		virtual const std::shared_ptr<base::AudioSink> _InputChannel(unsigned int channel,
 			Audible::AudioSourceType source) override;
 		virtual void _ArrangeChildren() override;
+		void _CollapseOtherTakeRouters();
 
 		gui::GuiRackParams _GetRackParams(utils::Size2d size);
 		std::optional<std::shared_ptr<LoopTake>> _TryGetTake(std::string id);

--- a/JammaLib/src/engine/Station.h
+++ b/JammaLib/src/engine/Station.h
@@ -119,6 +119,7 @@ namespace engine
 			Audible::AudioSourceType source) override;
 		virtual void _ArrangeChildren() override;
 		void _CollapseOtherTakeRouters();
+		void _CollapseOtherTakeRoutersToChannels();
 
 		gui::GuiRackParams _GetRackParams(utils::Size2d size);
 		std::optional<std::shared_ptr<LoopTake>> _TryGetTake(std::string id);

--- a/JammaLib/src/gui/GuiRack.cpp
+++ b/JammaLib/src/gui/GuiRack.cpp
@@ -60,17 +60,39 @@ void GuiRack::SetSize(utils::Size2d size)
 {
 	_rackParams.Size = size;
 
-	auto panelParams = _GetPanelParams(GuiRackParams::RACK_MASTER, size);
-	_masterPanel->SetSize(panelParams.Size);
-	auto sliderParams = _GetSliderParams(0, size);
-	_masterSlider->SetSize(sliderParams.Size);
-	_masterSlider->SetDragParams(sliderParams.DragControlOffset, sliderParams.DragControlSize, sliderParams.DragGap);
-	auto toggleParams = _GetToggleParams(GuiRackParams::RACK_CHANNELS, size);
-	_channelToggle->SetSize(toggleParams.Size);
+	auto masterPanelParams = _GetPanelParams(GuiRackParams::RACK_MASTER, size);
+	_masterPanel->SetPosition(masterPanelParams.Position);
+	_masterPanel->SetSize(masterPanelParams.Size);
+
+	auto masterSliderParams = _GetSliderParams(0, size);
+	_masterSlider->SetPosition(masterSliderParams.Position);
+	_masterSlider->SetSize(masterSliderParams.Size);
+	_masterSlider->SetDragParams(masterSliderParams.DragControlOffset, masterSliderParams.DragControlSize, masterSliderParams.DragGap);
+
+	auto channelToggleParams = _GetToggleParams(GuiRackParams::RACK_CHANNELS, size);
+	_channelToggle->SetPosition(channelToggleParams.Position);
+	_channelToggle->SetSize(channelToggleParams.Size);
+
+	auto channelPanelParams = _GetPanelParams(GuiRackParams::RACK_CHANNELS, size);
+	_channelPanel->SetPosition(channelPanelParams.Position);
+	_channelPanel->SetSize(channelPanelParams.Size);
+
+	auto routerToggleParams = _GetToggleParams(GuiRackParams::RACK_ROUTER, size);
+	_routerToggle->SetPosition(routerToggleParams.Position);
+	_routerToggle->SetSize(routerToggleParams.Size);
+
+	auto routerPanelParams = _GetPanelParams(GuiRackParams::RACK_ROUTER, size);
+	_routerPanel->SetPosition(routerPanelParams.Position);
+	_routerPanel->SetSize(routerPanelParams.Size);
+
+	auto routerParams = _GetRouterParams(size);
+	_router->SetPosition(routerParams.Position);
+	_router->SetSize(routerParams.Size);
 
 	for (auto i = 0u; i < _channelSliders.size(); ++i)
 	{
 		auto chanSliderParams = _GetSliderParams(i + 1, size);
+		_channelSliders[i]->SetPosition(chanSliderParams.Position);
 		_channelSliders[i]->SetSize(chanSliderParams.Size);
 		_channelSliders[i]->SetDragParams(chanSliderParams.DragControlOffset, chanSliderParams.DragControlSize, chanSliderParams.DragGap);
 	}

--- a/JammaLib/src/gui/GuiRack.cpp
+++ b/JammaLib/src/gui/GuiRack.cpp
@@ -58,12 +58,22 @@ GuiRack::GuiRack(GuiRackParams params) :
 
 void GuiRack::SetSize(utils::Size2d size)
 {
+	_rackParams.Size = size;
+
 	auto panelParams = _GetPanelParams(GuiRackParams::RACK_MASTER, size);
 	_masterPanel->SetSize(panelParams.Size);
 	auto sliderParams = _GetSliderParams(0, size);
 	_masterSlider->SetSize(sliderParams.Size);
+	_masterSlider->SetDragParams(sliderParams.DragControlOffset, sliderParams.DragControlSize, sliderParams.DragGap);
 	auto toggleParams = _GetToggleParams(GuiRackParams::RACK_CHANNELS, size);
 	_channelToggle->SetSize(toggleParams.Size);
+
+	for (auto i = 0u; i < _channelSliders.size(); ++i)
+	{
+		auto chanSliderParams = _GetSliderParams(i + 1, size);
+		_channelSliders[i]->SetSize(chanSliderParams.Size);
+		_channelSliders[i]->SetDragParams(chanSliderParams.DragControlOffset, chanSliderParams.DragControlSize, chanSliderParams.DragGap);
+	}
 
 	GuiElement::SetSize(size);
 }
@@ -91,19 +101,27 @@ ActionResult GuiRack::OnAction(GuiAction action)
 			newRackState = action.Index <= GuiRackParams::RACK_ROUTER ?
 				(GuiRackParams::RackState)action.Index :
 				GuiRackParams::RACK_MASTER;
-			
-			switch (newRackState)
-			{
-			case GuiRackParams::RACK_ROUTER:
-				_rackState = toggleOn ? GuiRackParams::RACK_ROUTER : GuiRackParams::RACK_CHANNELS;
-				break;
-			case GuiRackParams::RACK_CHANNELS:
-				if (routerVisible && toggleOn)
-					_rackState = GuiRackParams::RACK_ROUTER;
-				else
-					_rackState = toggleOn ? GuiRackParams::RACK_CHANNELS : GuiRackParams::RACK_MASTER;
 
-				break;
+			{
+				GuiRackParams::RackState computedState = _rackState;
+				if (newRackState == GuiRackParams::RACK_ROUTER)
+					computedState = toggleOn ? GuiRackParams::RACK_ROUTER : GuiRackParams::RACK_CHANNELS;
+				else if (newRackState == GuiRackParams::RACK_CHANNELS)
+					computedState = (routerVisible && toggleOn) ? GuiRackParams::RACK_ROUTER :
+						(toggleOn ? GuiRackParams::RACK_CHANNELS : GuiRackParams::RACK_MASTER);
+
+				// Pre-notify receiver before expanding to RACK_ROUTER so it can
+				// collapse any other take that already has the router open.
+				if (computedState == GuiRackParams::RACK_ROUTER && _rackState != GuiRackParams::RACK_ROUTER && _receiver)
+				{
+					GuiAction preNotify;
+					preNotify.ElementType = GuiAction::ACTIONELEMENT_RACK;
+					preNotify.Index = RackStateNotificationIndex;
+					preNotify.Data = GuiAction::GuiInt((int)GuiRackParams::RACK_ROUTER);
+					_receiver->OnAction(preNotify);
+				}
+
+				_rackState = computedState;
 			}
 			_OnRackChange(action.Index, true);
 			break;
@@ -273,8 +291,9 @@ gui::GuiSliderParams GuiRack::_GetSliderParams(unsigned int index, utils::Size2d
 		};
 	}
 
-	sliderParams.DragControlOffset = { (int)(sliderParams.Size.Width / 2) - (int)(_DragSize.Width / 2), (int)_DragGap.Height };
-	sliderParams.DragControlSize = _DragSize;
+	utils::Size2d dragSize = { std::min(_DragSize.Width, sliderSize.Width), std::min(_DragSize.Height, sliderSize.Height) };
+	sliderParams.DragControlOffset = { (int)(sliderParams.Size.Width / 2) - (int)(dragSize.Width / 2), (int)_DragGap.Height };
+	sliderParams.DragControlSize = dragSize;
 	sliderParams.DragGap = _DragGap;
 	sliderParams.Texture = "fader_back";
 	sliderParams.DragTexture = "fader";

--- a/JammaLib/src/gui/GuiRack.cpp
+++ b/JammaLib/src/gui/GuiRack.cpp
@@ -110,15 +110,26 @@ ActionResult GuiRack::OnAction(GuiAction action)
 					computedState = (routerVisible && toggleOn) ? GuiRackParams::RACK_ROUTER :
 						(toggleOn ? GuiRackParams::RACK_CHANNELS : GuiRackParams::RACK_MASTER);
 
-				// Pre-notify receiver before expanding to RACK_ROUTER so it can
-				// collapse any other take that already has the router open.
-				if (computedState == GuiRackParams::RACK_ROUTER && _rackState != GuiRackParams::RACK_ROUTER && _receiver)
+				// Pre-notify receiver before state change so it can collapse
+				// other takes appropriately based on the new state.
+				if (_receiver)
 				{
-					GuiAction preNotify;
-					preNotify.ElementType = GuiAction::ACTIONELEMENT_RACK;
-					preNotify.Index = RackStateNotificationIndex;
-					preNotify.Data = GuiAction::GuiInt((int)GuiRackParams::RACK_ROUTER);
-					_receiver->OnAction(preNotify);
+					if (computedState == GuiRackParams::RACK_ROUTER && _rackState != GuiRackParams::RACK_ROUTER)
+					{
+						GuiAction preNotify;
+						preNotify.ElementType = GuiAction::ACTIONELEMENT_RACK;
+						preNotify.Index = RackStateNotificationIndex;
+						preNotify.Data = GuiAction::GuiInt{(int)GuiRackParams::RACK_ROUTER};
+						_receiver->OnAction(preNotify);
+					}
+					else if (computedState == GuiRackParams::RACK_CHANNELS && _rackState == GuiRackParams::RACK_MASTER)
+					{
+						GuiAction preNotify;
+						preNotify.ElementType = GuiAction::ACTIONELEMENT_RACK;
+						preNotify.Index = RackStateNotificationIndex;
+						preNotify.Data = GuiAction::GuiInt{(int)GuiRackParams::RACK_CHANNELS};
+						_receiver->OnAction(preNotify);
+					}
 				}
 
 				_rackState = computedState;

--- a/JammaLib/src/gui/GuiRack.h
+++ b/JammaLib/src/gui/GuiRack.h
@@ -55,6 +55,8 @@ namespace gui
 		GuiRack(GuiRackParams params);
 
 	public:
+		static constexpr unsigned int RackStateNotificationIndex = ~0u;
+
 		virtual void SetSize(utils::Size2d size) override;
 
 		virtual actions::ActionResult OnAction(actions::GuiAction action) override;

--- a/JammaLib/src/gui/GuiSlider.cpp
+++ b/JammaLib/src/gui/GuiSlider.cpp
@@ -58,6 +58,7 @@ void GuiSlider::SetDragParams(utils::Position2d dragOffset,
 	_sliderParams.DragControlOffset = dragOffset;
 	_sliderParams.DragControlSize = dragSize;
 	_sliderParams.DragGap = dragGap;
+	_dragElement.SetSize(dragSize);
 
 	OnValueChange(true);
 }

--- a/JammaLib/src/resources/ResourceLib.cpp
+++ b/JammaLib/src/resources/ResourceLib.cpp
@@ -36,6 +36,8 @@ bool ResourceLib::LoadResource(Type type, std::string name, std::vector<std::str
 
 				return true;
 			}
+
+				break;
 		}
 		case SHADER:
 		{
@@ -44,9 +46,12 @@ bool ResourceLib::LoadResource(Type type, std::string name, std::vector<std::str
 			auto shader = ShaderResource::Load(vertFile, fragFile);
 
 			if (shader.has_value())
-				_resources.emplace(name, std::make_shared<ShaderResource>(name, shader.value(), args));
+				{
+					_resources.emplace(name, std::make_shared<ShaderResource>(name, shader.value(), args));
+					return true;
+				}
 
-			return true;
+				break;
 		}
 		case WAV:
 		{
@@ -57,9 +62,10 @@ bool ResourceLib::LoadResource(Type type, std::string name, std::vector<std::str
 			{ 
 				auto[wav, numSamps, sampleRate] = wavOpt.value();
 				_resources.emplace(name, std::make_shared<WavResource>(name, wav, numSamps, sampleRate));
+					return true;
 			}
 
-			return true;
+				break;
 		}
 	}
 

--- a/JammaLib/src/resources/ResourceLib.cpp
+++ b/JammaLib/src/resources/ResourceLib.cpp
@@ -37,7 +37,7 @@ bool ResourceLib::LoadResource(Type type, std::string name, std::vector<std::str
 				return true;
 			}
 
-				break;
+			break;
 		}
 		case SHADER:
 		{
@@ -46,12 +46,12 @@ bool ResourceLib::LoadResource(Type type, std::string name, std::vector<std::str
 			auto shader = ShaderResource::Load(vertFile, fragFile);
 
 			if (shader.has_value())
-				{
-					_resources.emplace(name, std::make_shared<ShaderResource>(name, shader.value(), args));
-					return true;
-				}
+			{
+				_resources.emplace(name, std::make_shared<ShaderResource>(name, shader.value(), args));
+				return true;
+			}
 
-				break;
+			break;
 		}
 		case WAV:
 		{
@@ -59,13 +59,13 @@ bool ResourceLib::LoadResource(Type type, std::string name, std::vector<std::str
 			auto wavOpt = WavResource::Load(wavFile);
 
 			if (wavOpt.has_value())
-			{ 
+			{
 				auto[wav, numSamps, sampleRate] = wavOpt.value();
 				_resources.emplace(name, std::make_shared<WavResource>(name, wav, numSamps, sampleRate));
-					return true;
+				return true;
 			}
 
-				break;
+			break;
 		}
 	}
 

--- a/test/JammaLib.Tests/JammaLib.Tests.vcxproj
+++ b/test/JammaLib.Tests/JammaLib.Tests.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="src\audio\MixBehaviour_Tests.cpp" />
     <ClCompile Include="src\audio\BufferBank_Tests.cpp" />
     <ClCompile Include="src\engine\LoopModel_Tests.cpp" />
+    <ClCompile Include="src\engine\StationRack_Tests.cpp" />
     <ClCompile Include="src\engine\Trigger_Tests.cpp" />
     <ClCompile Include="src\engine\UndoHistory_Tests.cpp" />
     <ClCompile Include="src\graphics\Window_Tests.cpp" />

--- a/test/JammaLib.Tests/JammaLib.Tests.vcxproj.filters
+++ b/test/JammaLib.Tests/JammaLib.Tests.vcxproj.filters
@@ -50,6 +50,9 @@
     <ClCompile Include="src\engine\FlipBuffer_Tests.cpp">
       <Filter>src\engine</Filter>
     </ClCompile>
+    <ClCompile Include="src\engine\StationRack_Tests.cpp">
+      <Filter>src\engine</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/test/JammaLib.Tests/src/engine/StationRack_Tests.cpp
+++ b/test/JammaLib.Tests/src/engine/StationRack_Tests.cpp
@@ -63,6 +63,18 @@ namespace
 		station->OnAction(action);
 		take->ForceRackState(gui::GuiRackParams::RACK_ROUTER);
 	}
+
+	void OpenChannelsOnTake(const std::shared_ptr<Station>& station,
+		const std::shared_ptr<TestLoopTake>& take)
+	{
+		GuiAction action;
+		action.ElementType = GuiAction::ACTIONELEMENT_RACK;
+		action.Index = gui::GuiRack::RackStateNotificationIndex;
+		action.Data = GuiAction::GuiInt{ (int)gui::GuiRackParams::RACK_CHANNELS };
+
+		station->OnAction(action);
+		take->ForceRackState(gui::GuiRackParams::RACK_CHANNELS);
+	}
 }
 
 TEST(StationRack, RouterOpenCollapsesCommittedSiblingRacksToMaster)
@@ -100,4 +112,41 @@ TEST(StationRack, RouterOpenCollapsesStagedSiblingRacksToMaster)
 
 	EXPECT_EQ(gui::GuiRackParams::RACK_MASTER, take0->GetRackState());
 	EXPECT_EQ(gui::GuiRackParams::RACK_ROUTER, take1->GetRackState());
+}
+
+TEST(StationRack, ChannelsOpenCollapsesCommittedRouterSiblingToChannels)
+{
+	auto station = MakeStation();
+	CommitInitial(station);
+
+	auto take0 = MakeTestLoopTake("take-0");
+	auto take1 = MakeTestLoopTake("take-1");
+	station->AddTake(take0);
+	station->AddTake(take1);
+	station->CommitChanges();
+
+	take0->ForceRackState(gui::GuiRackParams::RACK_ROUTER);
+	take1->ForceRackState(gui::GuiRackParams::RACK_CHANNELS);
+	OpenChannelsOnTake(station, take1);
+
+	EXPECT_EQ(gui::GuiRackParams::RACK_CHANNELS, take0->GetRackState());
+	EXPECT_EQ(gui::GuiRackParams::RACK_CHANNELS, take1->GetRackState());
+}
+
+TEST(StationRack, ChannelsOpenCollapsesStagedRouterSiblingToChannels)
+{
+	auto station = MakeStation();
+	CommitInitial(station);
+
+	auto take0 = MakeTestLoopTake("take-0");
+	auto take1 = MakeTestLoopTake("take-1");
+	station->AddTake(take0);
+	station->AddTake(take1);
+
+	take0->ForceRackState(gui::GuiRackParams::RACK_ROUTER);
+	take1->ForceRackState(gui::GuiRackParams::RACK_CHANNELS);
+	OpenChannelsOnTake(station, take1);
+
+	EXPECT_EQ(gui::GuiRackParams::RACK_CHANNELS, take0->GetRackState());
+	EXPECT_EQ(gui::GuiRackParams::RACK_CHANNELS, take1->GetRackState());
 }

--- a/test/JammaLib.Tests/src/engine/StationRack_Tests.cpp
+++ b/test/JammaLib.Tests/src/engine/StationRack_Tests.cpp
@@ -1,0 +1,103 @@
+#include "gtest/gtest.h"
+#include "actions/GuiAction.h"
+#include "engine/LoopTake.h"
+#include "engine/Station.h"
+
+using actions::GuiAction;
+using engine::LoopTake;
+using engine::LoopTakeParams;
+using engine::Station;
+using engine::StationParams;
+using audio::MergeMixBehaviourParams;
+
+namespace
+{
+	std::shared_ptr<Station> MakeStation(const std::string& name = "test-station")
+	{
+		StationParams params;
+		params.Name = name;
+		params.Size = { 200, 200 };
+		MergeMixBehaviourParams merge;
+		auto mixerParams = Station::GetMixerParams(params.Size, merge);
+		return std::make_shared<Station>(params, mixerParams);
+	}
+
+	void CommitInitial(const std::shared_ptr<Station>& station)
+	{
+		station->CommitChanges();
+	}
+
+	class TestLoopTake :
+		public LoopTake
+	{
+	public:
+		TestLoopTake(LoopTakeParams params, audio::AudioMixerParams mixerParams) :
+			LoopTake(params, mixerParams)
+		{
+		}
+
+		void ForceRackState(gui::GuiRackParams::RackState state)
+		{
+			_guiRack->SetRackState(state, true);
+		}
+	};
+
+	std::shared_ptr<TestLoopTake> MakeTestLoopTake(const std::string& id)
+	{
+		LoopTakeParams params;
+		params.Id = id;
+		params.Size = { 100, 100 };
+		MergeMixBehaviourParams merge;
+		auto mixerParams = LoopTake::GetMixerParams(params.Size, merge);
+		return std::make_shared<TestLoopTake>(params, mixerParams);
+	}
+
+	void OpenRouterOnTake(const std::shared_ptr<Station>& station,
+		const std::shared_ptr<TestLoopTake>& take)
+	{
+		GuiAction action;
+		action.ElementType = GuiAction::ACTIONELEMENT_RACK;
+		action.Index = gui::GuiRack::RackStateNotificationIndex;
+		action.Data = GuiAction::GuiInt{ (int)gui::GuiRackParams::RACK_ROUTER };
+
+		station->OnAction(action);
+		take->ForceRackState(gui::GuiRackParams::RACK_ROUTER);
+	}
+}
+
+TEST(StationRack, RouterOpenCollapsesCommittedSiblingRacksToMaster)
+{
+	auto station = MakeStation();
+	CommitInitial(station);
+
+	auto take0 = MakeTestLoopTake("take-0");
+	auto take1 = MakeTestLoopTake("take-1");
+	station->AddTake(take0);
+	station->AddTake(take1);
+	station->CommitChanges();
+
+	take0->ForceRackState(gui::GuiRackParams::RACK_CHANNELS);
+	take1->ForceRackState(gui::GuiRackParams::RACK_CHANNELS);
+	OpenRouterOnTake(station, take1);
+
+	EXPECT_EQ(gui::GuiRackParams::RACK_MASTER, take0->GetRackState());
+	EXPECT_EQ(gui::GuiRackParams::RACK_ROUTER, take1->GetRackState());
+}
+
+TEST(StationRack, RouterOpenCollapsesStagedSiblingRacksToMaster)
+{
+	auto station = MakeStation();
+	CommitInitial(station);
+
+	auto take0 = MakeTestLoopTake("take-0");
+	auto take1 = MakeTestLoopTake("take-1");
+	station->AddTake(take0);
+	station->AddTake(take1);
+
+	take0->ForceRackState(gui::GuiRackParams::RACK_CHANNELS);
+	take1->ForceRackState(gui::GuiRackParams::RACK_CHANNELS);
+	OpenRouterOnTake(station, take1);
+
+	EXPECT_EQ(gui::GuiRackParams::RACK_MASTER, take0->GetRackState());
+	EXPECT_EQ(gui::GuiRackParams::RACK_ROUTER, take1->GetRackState());
+}


### PR DESCRIPTION
Proportional size for all GuiRack channel sliders, was previously fixed in some cases.
Fully collapse other LoopTake GuiRacks when expanding a GuiRack to show its router.
Collapse other LoopTake GuiRacks back to hide router if expanding a different LoopTake GuiRack to show channels.