### PR TITLE
feat: Export session to directory via Ctrl+S

### DIFF
--- a/JammaLib/src/audio/AudioMixer.h
+++ b/JammaLib/src/audio/AudioMixer.h
@@ -242,6 +242,8 @@ namespace audio
 		void SetChannels(std::vector<unsigned int> channels);
 		void SetMaxChannels(unsigned int channels);
 		void SetBehaviour(std::unique_ptr<MixBehaviour> behaviour);
+		audio::BehaviourParams GetBehaviourParams() const
+			{ return _behaviour ? _behaviour->GetParams() : audio::BehaviourParams{}; }
 
 		// VU meter (owned by this mixer; value updated in WriteBlock).
 		void SetVuVisible(bool visible);

--- a/JammaLib/src/engine/Loop.cpp
+++ b/JammaLib/src/engine/Loop.cpp
@@ -406,6 +406,58 @@ std::string Loop::Id() const
 	return _loopParams.Id;
 }
 
+std::vector<float> Loop::ExportSamples() const
+{
+	if (_loopLength == 0 || _playState == STATE_INACTIVE)
+		return {};
+
+	std::vector<float> out(_loopLength);
+	for (unsigned long i = 0; i < _loopLength; ++i)
+		out[i] = _bufferBank[constants::MaxLoopFadeSamps + i];
+	return out;
+}
+
+io::JamFile::Loop Loop::ToJamFile(const std::string& wavFilename) const
+{
+	io::JamFile::Loop s;
+	s.Name   = wavFilename;
+	s.Length = _loopLength;
+	// Logical play index: strip the crossfade pre-roll offset
+	s.Index  = (_playIndex >= constants::MaxLoopFadeSamps)
+	               ? _playIndex - constants::MaxLoopFadeSamps : 0ul;
+	s.MasterLoopCount = 0; // restart from beginning on reload
+	s.Level  = _mixer->UnmutedLevel();
+	s.Speed  = _pitch;
+	s.Muted  = IsMuted();
+	s.MuteGroups   = 0; // not yet tracked in engine
+	s.SelectGroups = 0;
+
+	// Reconstruct LoopMix from mixer behaviour
+	auto params = _mixer->GetBehaviourParams();
+	if (auto* wire = std::get_if<audio::WireMixBehaviourParams>(&params))
+	{
+		s.Mix.Mix = io::JamFile::LoopMix::MIX_WIRE;
+		std::vector<unsigned long> chans;
+		for (auto c : wire->Channels) chans.push_back(c);
+		s.Mix.Params = chans;
+	}
+	else if (auto* pan = std::get_if<audio::PanMixBehaviourParams>(&params))
+	{
+		s.Mix.Mix = io::JamFile::LoopMix::MIX_PAN;
+		std::vector<double> levels;
+		for (auto l : pan->ChannelLevels) levels.push_back(l);
+		s.Mix.Params = levels;
+	}
+	else
+	{
+		// Fallback: mono centre pan
+		s.Mix.Mix = io::JamFile::LoopMix::MIX_PAN;
+		s.Mix.Params = std::vector<double>{ 0.5, 0.5 };
+	}
+
+	return s;
+}
+
 void Loop::Update()
 {
 	_UpdateLoopModel();

--- a/JammaLib/src/engine/Loop.cpp
+++ b/JammaLib/src/engine/Loop.cpp
@@ -413,16 +413,21 @@ std::vector<float> Loop::ExportSamples() const
 
 	std::vector<float> out(_loopLength);
 	unsigned long copied = 0;
+	// Compute bank offset once for the first chunk; subsequent chunks always
+	// start at a bank boundary (offset 0) so bankOffset resets to 0 after the first.
+	unsigned long bankOffset = constants::MaxLoopFadeSamps % BufferBank::_BufferBankSize;
 	while (copied < _loopLength)
 	{
 		const unsigned long idx = constants::MaxLoopFadeSamps + copied;
-		const unsigned long bankOffset = idx % BufferBank::_BufferBankSize;
 		const unsigned long samplesInBank = BufferBank::_BufferBankSize - bankOffset;
 		const unsigned long chunkSize = std::min(_loopLength - copied, samplesInBank);
 		const float* ptr = _bufferBank.BlockPtr(idx);
+		// ptr is null only if idx >= Capacity(), which cannot happen for a
+		// properly-initialised loop; if it does, leave those samples as 0.
 		if (ptr != nullptr)
 			std::copy_n(ptr, chunkSize, out.data() + copied);
 		copied += chunkSize;
+		bankOffset = 0; // all subsequent chunks start at a bank boundary
 	}
 	return out;
 }

--- a/JammaLib/src/engine/Loop.cpp
+++ b/JammaLib/src/engine/Loop.cpp
@@ -412,8 +412,18 @@ std::vector<float> Loop::ExportSamples() const
 		return {};
 
 	std::vector<float> out(_loopLength);
-	for (unsigned long i = 0; i < _loopLength; ++i)
-		out[i] = _bufferBank[constants::MaxLoopFadeSamps + i];
+	unsigned long copied = 0;
+	while (copied < _loopLength)
+	{
+		const unsigned long idx = constants::MaxLoopFadeSamps + copied;
+		const unsigned long bankOffset = idx % BufferBank::_BufferBankSize;
+		const unsigned long samplesInBank = BufferBank::_BufferBankSize - bankOffset;
+		const unsigned long chunkSize = std::min(_loopLength - copied, samplesInBank);
+		const float* ptr = _bufferBank.BlockPtr(idx);
+		if (ptr != nullptr)
+			std::copy_n(ptr, chunkSize, out.data() + copied);
+		copied += chunkSize;
+	}
 	return out;
 }
 

--- a/JammaLib/src/engine/Loop.h
+++ b/JammaLib/src/engine/Loop.h
@@ -179,6 +179,12 @@ namespace engine
 		std::string Id() const;
 		LoopPlayState PlayState() const { return _playState; }
 
+		// Returns the loop's audio samples for WAV export (empty if inactive).
+		std::vector<float> ExportSamples() const;
+		// Fills a JamFile::Loop struct from current engine state.
+		// wavFilename is the bare filename that will appear in the .jam (e.g. "id.wav").
+		io::JamFile::Loop ToJamFile(const std::string& wavFilename) const;
+
 		void Update();
 		void SetMixerLevel(double level);
 		bool Load(const io::WavReadWriter& readWriter);

--- a/JammaLib/src/engine/LoopTake.h
+++ b/JammaLib/src/engine/LoopTake.h
@@ -117,6 +117,7 @@ namespace engine
 		std::string Id() const;
 		std::string SourceId() const;
 		LoopTakeSource TakeSourceType() const;
+		const std::vector<std::shared_ptr<Loop>>& GetLoops() const { return _loops; }
 		LoopTakeState TakeState() const;
 		unsigned long NumRecordedSamps() const;
 		std::shared_ptr<Loop> AddLoop(unsigned int chan, std::string stationName);

--- a/JammaLib/src/engine/Scene.cpp
+++ b/JammaLib/src/engine/Scene.cpp
@@ -526,10 +526,14 @@ ActionResult Scene::OnAction(KeyAction action)
 
 		io::TextReadWriter textWriter;
 		const auto jamPath = exportDir + L"\\session.jam";
-		textWriter.Write(jamPath, jamStream.str(), 0, 0);
+		const bool jamOk = textWriter.Write(jamPath, jamStream.str(), 0, 0);
 
-		std::cout << "Exported " << wavCount << " loop(s) + session.jam to "
-		          << utils::EncodeUtf8(exportDir) << std::endl;
+		if (jamOk)
+			std::cout << "Exported " << wavCount << " loop(s) + session.jam to "
+			          << utils::EncodeUtf8(exportDir) << std::endl;
+		else
+			std::cout << "Export: wrote " << wavCount << " WAV(s) but failed to write session.jam to "
+			          << utils::EncodeUtf8(exportDir) << std::endl;
 
 		return ActionResult::NoAction();
 	}

--- a/JammaLib/src/engine/Scene.cpp
+++ b/JammaLib/src/engine/Scene.cpp
@@ -411,6 +411,129 @@ ActionResult Scene::OnAction(KeyAction action)
 		return { res };
 	}
 
+	// Ctrl+S — export session to directory
+	if ((83 == action.KeyChar) && (actions::KeyAction::KEY_UP == action.KeyActionType) && (Action::MODIFIER_CTRL & action.Modifiers))
+	{
+		auto exportDir = utils::PickDirectory(L"Choose export directory");
+		if (exportDir.empty())
+			return ActionResult::NoAction();
+
+		// Snapshot structs (defined locally — exported data is plain data, no engine types)
+		struct LoopSnapshot {
+			std::string        wavFilename;
+			std::vector<float> samples;
+			io::JamFile::Loop  jamLoop;
+		};
+		struct TakeSnapshot {
+			std::string                takeId;
+			std::vector<LoopSnapshot>  loops;
+		};
+		struct StationSnapshot {
+			std::string                  stationName;
+			unsigned int                 stationType;
+			std::vector<TakeSnapshot>    takes;
+		};
+
+		std::vector<StationSnapshot> stationData;
+		const auto sampleRate = _audioDevice->GetAudioStreamParams().SampleRate;
+
+		// --- snapshot under audio lock (memory copies only — keep this fast) ---
+		{
+			std::lock_guard<std::mutex> lock(_audioMutex);
+
+			for (auto& station : _stations)
+			{
+				StationSnapshot stSnap;
+				stSnap.stationName = station->Name();
+				stSnap.stationType = 0; // extend when Station exposes StationType
+
+				for (auto& take : station->GetLoopTakes())
+				{
+					TakeSnapshot tkSnap;
+					tkSnap.takeId = take->Id();
+
+					for (auto& loop : take->GetLoops())
+					{
+						auto samples = loop->ExportSamples();
+						if (samples.empty())
+							continue;
+
+						const auto wavFilename = loop->Id() + ".wav";
+						LoopSnapshot lpSnap;
+						lpSnap.wavFilename = wavFilename;
+						lpSnap.samples     = std::move(samples);
+						lpSnap.jamLoop     = loop->ToJamFile(wavFilename);
+						tkSnap.loops.push_back(std::move(lpSnap));
+					}
+
+					if (!tkSnap.loops.empty())
+						stSnap.takes.push_back(std::move(tkSnap));
+				}
+
+				if (!stSnap.takes.empty())
+					stationData.push_back(std::move(stSnap));
+			}
+		}
+		// audio lock released
+
+		if (stationData.empty())
+		{
+			std::cout << "Export: nothing to export" << std::endl;
+			return ActionResult::NoAction();
+		}
+
+		// --- build JamFile struct ---
+		io::JamFile jam;
+		jam.Version       = io::JamFile::VERSION_V;
+		jam.Name          = "export";
+		jam.TimerTicks    = 0;
+		jam.QuantiseSamps = 0;
+		jam.Quantisation  = engine::Timer::QUANTISE_OFF;
+
+		for (auto& stSnap : stationData)
+		{
+			io::JamFile::Station st;
+			st.Name        = stSnap.stationName;
+			st.StationType = stSnap.stationType;
+
+			for (auto& tkSnap : stSnap.takes)
+			{
+				io::JamFile::LoopTake take;
+				take.Name = tkSnap.takeId;
+				for (auto& lpSnap : tkSnap.loops)
+					take.Loops.push_back(lpSnap.jamLoop);
+				st.LoopTakes.push_back(std::move(take));
+			}
+			jam.Stations.push_back(std::move(st));
+		}
+
+		// --- write WAV files ---
+		io::WavReadWriter wavWriter;
+		unsigned int wavCount = 0;
+		for (auto& stSnap : stationData)
+			for (auto& tkSnap : stSnap.takes)
+				for (auto& lpSnap : tkSnap.loops)
+				{
+					const auto path = exportDir + L"\\" + utils::DecodeUtf8(lpSnap.wavFilename);
+					if (wavWriter.Write(path, lpSnap.samples,
+					                    (unsigned int)lpSnap.samples.size(), sampleRate))
+						++wavCount;
+				}
+
+		// --- write .jam file ---
+		std::stringstream jamStream;
+		io::JamFile::ToStream(jam, jamStream);
+
+		io::TextReadWriter textWriter;
+		const auto jamPath = exportDir + L"\\session.jam";
+		textWriter.Write(jamPath, jamStream.str(), 0, 0);
+
+		std::cout << "Exported " << wavCount << " loop(s) + session.jam to "
+		          << utils::EncodeUtf8(exportDir) << std::endl;
+
+		return ActionResult::NoAction();
+	}
+
 	bool checkReset = false;
 
 	for (auto& station : _stations)

--- a/JammaLib/src/engine/Station.h
+++ b/JammaLib/src/engine/Station.h
@@ -101,6 +101,7 @@ namespace engine
 		unsigned int NumTakes() const;
 		std::string Name() const;
 		void SetName(std::string name);
+		const std::vector<std::shared_ptr<LoopTake>>& GetLoopTakes() const { return _loopTakes; }
 		void SetClock(std::shared_ptr<Timer> clock);
 		void SetupBuffers(unsigned int bufSize);
 		void SetNumBusChannels(unsigned int chans);

--- a/JammaLib/src/io/JamFile.cpp
+++ b/JammaLib/src/io/JamFile.cpp
@@ -94,17 +94,18 @@ bool JamFile::ToStream(JamFile jam, std::stringstream& ss)
 {
 	// Local helpers
 	auto quoted  = [](const std::string& s) { return '"' + s + '"'; };
+	auto fmtDouble = [](double v) -> std::string {
+	                     std::ostringstream o;
+	                     o.imbue(std::locale::classic());
+	                     o << std::fixed << std::setprecision(10) << v;
+	                     return o.str();
+	                 };
 	auto kvStr   = [&](const std::string& k, const std::string& v)
 	                   { return quoted(k) + ":" + quoted(v); };
 	auto kvUlong = [&](const std::string& k, unsigned long v)
 	                   { return quoted(k) + ":" + std::to_string(v); };
 	auto kvDouble = [&](const std::string& k, double v)
-	                   {
-	                       std::ostringstream o;
-	                       o.imbue(std::locale::classic());
-	                       o << std::fixed << std::setprecision(10) << v;
-	                       return quoted(k) + ":" + o.str();
-	                   };
+	                   { return quoted(k) + ":" + fmtDouble(v); };
 	auto kvBool  = [&](const std::string& k, bool v)
 	                   { return quoted(k) + ":" + (v ? "true" : "false"); };
 
@@ -127,12 +128,7 @@ bool JamFile::ToStream(JamFile jam, std::stringstream& ss)
 		{
 			const auto& v = std::get<std::vector<double>>(m.Params);
 			for (size_t i = 0; i < v.size(); ++i)
-			{
-				std::ostringstream o;
-				o.imbue(std::locale::classic());
-				o << std::fixed << std::setprecision(10) << v[i];
-				chans += (i ? "," : "") + o.str();
-			}
+				chans += (i ? "," : "") + fmtDouble(v[i]);
 		}
 		return "{" + kvStr("type", typeStr) + "," + quoted("chans") + ":[" + chans + "]}";
 	};

--- a/JammaLib/src/io/JamFile.cpp
+++ b/JammaLib/src/io/JamFile.cpp
@@ -6,6 +6,7 @@
 ///////////////////////////////////////////////////////////
 
 #include "JamFile.h"
+#include <sstream>
 
 using namespace io;
 using audio::BehaviourParams;
@@ -89,39 +90,85 @@ std::optional<JamFile> JamFile::FromStream(std::stringstream ss)
 
 bool JamFile::ToStream(JamFile jam, std::stringstream& ss)
 {
-	ss << "Version: " << jam.Version << std::endl;
-	ss << "Name: " << jam.Name << std::endl;
-	ss << "TimerTicks: " << jam.TimerTicks << std::endl;
-	ss << "QuantiseSamps: " << jam.QuantiseSamps << std::endl;
-	ss << "Quantisation: " << jam.Quantisation << std::endl;
+	// Local helpers
+	auto quoted  = [](const std::string& s) { return '"' + s + '"'; };
+	auto kvStr   = [&](const std::string& k, const std::string& v)
+	                   { return quoted(k) + ":" + quoted(v); };
+	auto kvUlong = [&](const std::string& k, unsigned long v)
+	                   { return quoted(k) + ":" + std::to_string(v); };
+	auto kvDouble = [&](const std::string& k, double v)
+	                   { std::ostringstream o; o << v; return quoted(k) + ":" + o.str(); };
+	auto kvBool  = [&](const std::string& k, bool v)
+	                   { return quoted(k) + ":" + (v ? "true" : "false"); };
 
-	for (auto &station : jam.Stations)
-	{
-		ss << "=== Station ===" << std::endl;
-		ss << "Name: " << station.Name << std::endl;
-		ss << "StationType: " << station.StationType << std::endl;
+	auto quantStr = [](engine::Timer::QuantisationType q) -> std::string {
+		if (q == engine::Timer::QUANTISE_MULTIPLE) return "multiple";
+		if (q == engine::Timer::QUANTISE_POWER)    return "power";
+		return "off";
+	};
 
-		for (auto& loopTake : station.LoopTakes)
+	auto mixStr = [&](const JamFile::LoopMix& m) -> std::string {
+		const std::string typeStr = (m.Mix == LoopMix::MIX_WIRE) ? "wire" : "pan";
+		std::string chans;
+		if (m.Mix == LoopMix::MIX_WIRE)
 		{
-			ss << "====== LoopTake ======" << std::endl;
-			ss << "Name: " << loopTake.Name << std::endl;
-
-			for (auto& loop: loopTake.Loops)
-			{
-				ss << "========= Loop =========" << std::endl;
-				ss << "Name: " << loop.Name << std::endl;
-				ss << "Length: " << loop.Length << std::endl;
-				ss << "Index: " << loop.Index << std::endl;
-				ss << "MasterLoopCount: " << loop.MasterLoopCount << std::endl;
-				ss << "Level: " << loop.Level << std::endl;
-				ss << "Muted: " << loop.Muted << std::endl;
-				ss << "MixType: " << loop.Mix.Mix << std::endl;
-				ss << "MuteGroups: " << loop.MuteGroups << std::endl;
-				ss << "SelectGroups: " << loop.SelectGroups << std::endl;
-			}
+			const auto& v = std::get<std::vector<unsigned long>>(m.Params);
+			for (size_t i = 0; i < v.size(); ++i)
+				chans += (i ? "," : "") + std::to_string(v[i]);
 		}
-	}
+		else
+		{
+			const auto& v = std::get<std::vector<double>>(m.Params);
+			for (size_t i = 0; i < v.size(); ++i)
+			{ std::ostringstream o; o << v[i]; chans += (i ? "," : "") + o.str(); }
+		}
+		return "{" + kvStr("type", typeStr) + "," + quoted("chans") + ":[" + chans + "]}";
+	};
 
+	ss << "{";
+	ss << kvStr("name", jam.Name) << ",";
+	ss << kvUlong("timerticks", jam.TimerTicks) << ",";
+	ss << kvUlong("quantisesamps", jam.QuantiseSamps) << ",";
+	ss << kvStr("quantisation", quantStr(jam.Quantisation)) << ",";
+	ss << quoted("stations") << ":["; 
+
+	for (size_t si = 0; si < jam.Stations.size(); ++si)
+	{
+		const auto& st = jam.Stations[si];
+		if (si) ss << ",";
+		ss << "{" << kvStr("name", st.Name) << ","
+		          << kvUlong("stationtype", st.StationType) << ","
+		          << quoted("takes") << ":["; 
+
+		for (size_t ti = 0; ti < st.LoopTakes.size(); ++ti)
+		{
+			const auto& take = st.LoopTakes[ti];
+			if (ti) ss << ",";
+			ss << "{" << kvStr("name", take.Name) << ","
+			          << quoted("loops") << ":["; 
+
+			for (size_t li = 0; li < take.Loops.size(); ++li)
+			{
+				const auto& lp = take.Loops[li];
+				if (li) ss << ",";
+				ss << "{"
+				   << kvStr("name",             lp.Name)               << ","
+				   << kvUlong("length",          lp.Length)             << ","
+				   << kvUlong("index",           lp.Index)              << ","
+				   << kvUlong("masterloopcount", lp.MasterLoopCount)    << ","
+				   << kvDouble("level",          lp.Level)              << ","
+				   << kvDouble("speed",          lp.Speed)              << ","
+				   << kvUlong("mutegroups",      lp.MuteGroups)         << ","
+				   << kvUlong("selectgroups",    lp.SelectGroups)       << ","
+				   << kvBool("muted",            lp.Muted)              << ","
+				   << quoted("mix") << ":" << mixStr(lp.Mix)
+				   << "}";
+			}
+			ss << "]}";	// close loops array + take object
+		}
+		ss << "]}";		// close takes array + station object
+	}
+	ss << "]}";			// close stations array + root object
 	return true;
 }
 

--- a/JammaLib/src/io/JamFile.cpp
+++ b/JammaLib/src/io/JamFile.cpp
@@ -7,6 +7,8 @@
 
 #include "JamFile.h"
 #include <sstream>
+#include <iomanip>
+#include <locale>
 
 using namespace io;
 using audio::BehaviourParams;
@@ -97,7 +99,12 @@ bool JamFile::ToStream(JamFile jam, std::stringstream& ss)
 	auto kvUlong = [&](const std::string& k, unsigned long v)
 	                   { return quoted(k) + ":" + std::to_string(v); };
 	auto kvDouble = [&](const std::string& k, double v)
-	                   { std::ostringstream o; o << v; return quoted(k) + ":" + o.str(); };
+	                   {
+	                       std::ostringstream o;
+	                       o.imbue(std::locale::classic());
+	                       o << std::fixed << std::setprecision(10) << v;
+	                       return quoted(k) + ":" + o.str();
+	                   };
 	auto kvBool  = [&](const std::string& k, bool v)
 	                   { return quoted(k) + ":" + (v ? "true" : "false"); };
 
@@ -120,7 +127,12 @@ bool JamFile::ToStream(JamFile jam, std::stringstream& ss)
 		{
 			const auto& v = std::get<std::vector<double>>(m.Params);
 			for (size_t i = 0; i < v.size(); ++i)
-			{ std::ostringstream o; o << v[i]; chans += (i ? "," : "") + o.str(); }
+			{
+				std::ostringstream o;
+				o.imbue(std::locale::classic());
+				o << std::fixed << std::setprecision(10) << v[i];
+				chans += (i ? "," : "") + o.str();
+			}
 		}
 		return "{" + kvStr("type", typeStr) + "," + quoted("chans") + ":[" + chans + "]}";
 	};

--- a/JammaLib/src/utils/PathUtils.cpp
+++ b/JammaLib/src/utils/PathUtils.cpp
@@ -6,6 +6,7 @@
 ///////////////////////////////////////////////////////////
 
 #include <windows.h>
+#include <shobjidl_core.h>
 #include "PathUtils.h"
 
 std::wstring utils::GetPath(PathType pathType)
@@ -30,4 +31,43 @@ std::wstring utils::GetParentDirectory(std::wstring dir)
 {
 	std::filesystem::path p(dir);
 	return p.parent_path();
+}
+
+std::wstring utils::PickDirectory(const std::wstring& title)
+{
+	std::wstring result;
+
+	// Initialise COM for this call if not already done on this thread.
+	struct ComGuard {
+		bool initialised;
+		ComGuard() { initialised = SUCCEEDED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED)); }
+		~ComGuard() { if (initialised) CoUninitialize(); }
+	} comGuard;
+
+	IFileOpenDialog* pfd = nullptr;
+	if (FAILED(CoCreateInstance(CLSID_FileOpenDialog, nullptr,
+	                            CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pfd))))
+		return result;
+
+	DWORD opts = 0;
+	pfd->GetOptions(&opts);
+	pfd->SetOptions(opts | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+	pfd->SetTitle(title.c_str());
+
+	if (SUCCEEDED(pfd->Show(nullptr)))
+	{
+		IShellItem* psi = nullptr;
+		if (SUCCEEDED(pfd->GetResult(&psi)))
+		{
+			PWSTR path = nullptr;
+			if (SUCCEEDED(psi->GetDisplayName(SIGDN_FILESYSPATH, &path)))
+			{
+				result = path;
+				CoTaskMemFree(path);
+			}
+			psi->Release();
+		}
+	}
+	pfd->Release();
+	return result;
 }

--- a/JammaLib/src/utils/PathUtils.h
+++ b/JammaLib/src/utils/PathUtils.h
@@ -21,4 +21,8 @@ namespace utils
 
 	std::wstring GetPath(PathType pathType);
 	std::wstring GetParentDirectory(std::wstring dir);
+
+	// Shows a native folder-picker dialog.
+	// Returns the chosen path, or an empty wstring if the user cancelled.
+	std::wstring PickDirectory(const std::wstring& title = L"Choose export directory");
 }

--- a/test/JammaLib.Tests/src/io/JamFile_Tests.cpp
+++ b/test/JammaLib.Tests/src/io/JamFile_Tests.cpp
@@ -184,3 +184,258 @@ TEST(JamFile, ParsesFile) {
 	ASSERT_EQ(4321, jam.value().QuantiseSamps);
 	ASSERT_EQ(engine::Timer::QUANTISE_POWER, jam.value().Quantisation);
 }
+
+// ---------------------------------------------------------------------------
+// ToStream -> FromStream round-trip tests
+// ---------------------------------------------------------------------------
+
+namespace
+{
+	// Helper: build a minimal Loop with a pan mix.
+	JamFile::Loop MakePanLoop(const std::string& name,
+	                          unsigned long length,
+	                          unsigned long index,
+	                          double level,
+	                          double speed)
+	{
+		JamFile::LoopMix mix;
+		mix.Mix = JamFile::LoopMix::MIX_PAN;
+		mix.Params = std::vector<double>{ 0.25, 0.75 };
+
+		JamFile::Loop loop;
+		loop.Name            = name;
+		loop.Length          = length;
+		loop.Index           = index;
+		loop.MasterLoopCount = 2;
+		loop.Level           = level;
+		loop.Speed           = speed;
+		loop.MuteGroups      = 0;
+		loop.SelectGroups    = 0;
+		loop.Muted           = false;
+		loop.Mix             = mix;
+		return loop;
+	}
+
+	// Helper: build a minimal Loop with a wire mix.
+	JamFile::Loop MakeWireLoop(const std::string& name)
+	{
+		JamFile::LoopMix mix;
+		mix.Mix    = JamFile::LoopMix::MIX_WIRE;
+		mix.Params = std::vector<unsigned long>{ 0, 1 };
+
+		JamFile::Loop loop;
+		loop.Name            = name;
+		loop.Length          = 44100;
+		loop.Index           = 0;
+		loop.MasterLoopCount = 0;
+		loop.Level           = 1.0;
+		loop.Speed           = 1.0;
+		loop.MuteGroups      = 0;
+		loop.SelectGroups    = 0;
+		loop.Muted           = true;
+		loop.Mix             = mix;
+		return loop;
+	}
+} // anonymous namespace
+
+TEST(JamFile, ToStream_RoundTrip_Basic) {
+	JamFile::LoopTake take;
+	take.Name  = "take1";
+	take.Loops = { MakePanLoop("loop1.wav", 100000, 42, 0.75, 1.0) };
+
+	JamFile::Station station;
+	station.Name       = "station1";
+	station.StationType = 0;
+	station.LoopTakes  = { take };
+
+	JamFile jam;
+	jam.Version       = JamFile::VERSION_V;
+	jam.Name          = "mysession";
+	jam.TimerTicks    = 12345;
+	jam.QuantiseSamps = 77911;
+	jam.Quantisation  = engine::Timer::QUANTISE_MULTIPLE;
+	jam.Stations      = { station };
+
+	std::stringstream ss;
+	ASSERT_TRUE(JamFile::ToStream(jam, ss));
+
+	auto result = JamFile::FromStream(std::move(ss));
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(0, result.value().Name.compare("mysession"));
+	ASSERT_EQ(12345ul, result.value().TimerTicks);
+	ASSERT_EQ(77911u, result.value().QuantiseSamps);
+	ASSERT_EQ(engine::Timer::QUANTISE_MULTIPLE, result.value().Quantisation);
+
+	ASSERT_EQ(1u, result.value().Stations.size());
+	ASSERT_EQ(0, result.value().Stations[0].Name.compare("station1"));
+
+	ASSERT_EQ(1u, result.value().Stations[0].LoopTakes.size());
+	ASSERT_EQ(0, result.value().Stations[0].LoopTakes[0].Name.compare("take1"));
+
+	ASSERT_EQ(1u, result.value().Stations[0].LoopTakes[0].Loops.size());
+	const auto& lp = result.value().Stations[0].LoopTakes[0].Loops[0];
+	ASSERT_EQ(0, lp.Name.compare("loop1.wav"));
+	ASSERT_EQ(100000ul, lp.Length);
+	ASSERT_EQ(42ul, lp.Index);
+	ASSERT_EQ(2ul, lp.MasterLoopCount);
+	ASSERT_DOUBLE_EQ(0.75, lp.Level);
+	ASSERT_DOUBLE_EQ(1.0,  lp.Speed);
+	ASSERT_EQ(false, lp.Muted);
+
+	ASSERT_EQ(JamFile::LoopMix::MIX_PAN, lp.Mix.Mix);
+	const auto& chans = std::get<std::vector<double>>(lp.Mix.Params);
+	ASSERT_EQ(2u, chans.size());
+	ASSERT_DOUBLE_EQ(0.25, chans[0]);
+	ASSERT_DOUBLE_EQ(0.75, chans[1]);
+}
+
+TEST(JamFile, ToStream_RoundTrip_WireMix) {
+	JamFile::LoopTake take;
+	take.Name  = "take1";
+	take.Loops = { MakeWireLoop("loop1.wav") };
+
+	JamFile::Station station;
+	station.Name        = "station1";
+	station.StationType = 0;
+	station.LoopTakes   = { take };
+
+	JamFile jam;
+	jam.Version       = JamFile::VERSION_V;
+	jam.Name          = "wiresession";
+	jam.TimerTicks    = 0;
+	jam.QuantiseSamps = 0;
+	jam.Quantisation  = engine::Timer::QUANTISE_OFF;
+	jam.Stations      = { station };
+
+	std::stringstream ss;
+	ASSERT_TRUE(JamFile::ToStream(jam, ss));
+
+	auto result = JamFile::FromStream(std::move(ss));
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(0, result.value().Name.compare("wiresession"));
+	ASSERT_EQ(engine::Timer::QUANTISE_OFF, result.value().Quantisation);
+
+	ASSERT_EQ(1u, result.value().Stations.size());
+	ASSERT_EQ(1u, result.value().Stations[0].LoopTakes.size());
+	ASSERT_EQ(1u, result.value().Stations[0].LoopTakes[0].Loops.size());
+
+	const auto& lp = result.value().Stations[0].LoopTakes[0].Loops[0];
+	ASSERT_EQ(true, lp.Muted);
+	ASSERT_EQ(JamFile::LoopMix::MIX_WIRE, lp.Mix.Mix);
+	const auto& chans = std::get<std::vector<unsigned long>>(lp.Mix.Params);
+	ASSERT_EQ(2u, chans.size());
+	ASSERT_EQ(0ul, chans[0]);
+	ASSERT_EQ(1ul, chans[1]);
+}
+
+TEST(JamFile, ToStream_RoundTrip_MultipleStations) {
+	JamFile::LoopTake take1;
+	take1.Name  = "take1";
+	take1.Loops = { MakePanLoop("a.wav", 1000, 1, 0.5, 1.0),
+	                MakePanLoop("b.wav", 2000, 2, 0.8, 0.5) };
+
+	JamFile::LoopTake take2;
+	take2.Name  = "take2";
+	take2.Loops = { MakePanLoop("c.wav", 3000, 3, 1.0, 2.0) };
+
+	JamFile::Station st1;
+	st1.Name        = "drums";
+	st1.StationType = 0;
+	st1.LoopTakes   = { take1, take2 };
+
+	JamFile::LoopTake take3;
+	take3.Name  = "take3";
+	take3.Loops = { MakePanLoop("d.wav", 4000, 4, 0.6, 1.0) };
+
+	JamFile::Station st2;
+	st2.Name        = "bass";
+	st2.StationType = 0;
+	st2.LoopTakes   = { take3 };
+
+	JamFile jam;
+	jam.Version       = JamFile::VERSION_V;
+	jam.Name          = "multisession";
+	jam.TimerTicks    = 99;
+	jam.QuantiseSamps = 4410;
+	jam.Quantisation  = engine::Timer::QUANTISE_POWER;
+	jam.Stations      = { st1, st2 };
+
+	std::stringstream ss;
+	ASSERT_TRUE(JamFile::ToStream(jam, ss));
+
+	auto result = JamFile::FromStream(std::move(ss));
+	ASSERT_TRUE(result.has_value());
+
+	ASSERT_EQ(0, result.value().Name.compare("multisession"));
+	ASSERT_EQ(99ul, result.value().TimerTicks);
+	ASSERT_EQ(4410u, result.value().QuantiseSamps);
+	ASSERT_EQ(engine::Timer::QUANTISE_POWER, result.value().Quantisation);
+
+	ASSERT_EQ(2u, result.value().Stations.size());
+
+	ASSERT_EQ(0, result.value().Stations[0].Name.compare("drums"));
+	ASSERT_EQ(2u, result.value().Stations[0].LoopTakes.size());
+	ASSERT_EQ(2u, result.value().Stations[0].LoopTakes[0].Loops.size());
+	ASSERT_EQ(1u, result.value().Stations[0].LoopTakes[1].Loops.size());
+	ASSERT_EQ(0, result.value().Stations[0].LoopTakes[0].Loops[0].Name.compare("a.wav"));
+	ASSERT_EQ(1ul, result.value().Stations[0].LoopTakes[0].Loops[0].Index);
+	ASSERT_EQ(0, result.value().Stations[0].LoopTakes[0].Loops[1].Name.compare("b.wav"));
+	ASSERT_EQ(2ul, result.value().Stations[0].LoopTakes[0].Loops[1].Index);
+	ASSERT_EQ(0, result.value().Stations[0].LoopTakes[1].Loops[0].Name.compare("c.wav"));
+	ASSERT_EQ(3ul, result.value().Stations[0].LoopTakes[1].Loops[0].Index);
+
+	ASSERT_EQ(0, result.value().Stations[1].Name.compare("bass"));
+	ASSERT_EQ(1u, result.value().Stations[1].LoopTakes.size());
+	ASSERT_EQ(0, result.value().Stations[1].LoopTakes[0].Loops[0].Name.compare("d.wav"));
+	ASSERT_EQ(4ul, result.value().Stations[1].LoopTakes[0].Loops[0].Index);
+}
+
+TEST(JamFile, ToStream_RoundTrip_EmptyStations) {
+	JamFile jam;
+	jam.Version       = JamFile::VERSION_V;
+	jam.Name          = "empty";
+	jam.TimerTicks    = 0;
+	jam.QuantiseSamps = 0;
+	jam.Quantisation  = engine::Timer::QUANTISE_OFF;
+
+	std::stringstream ss;
+	ASSERT_TRUE(JamFile::ToStream(jam, ss));
+
+	auto result = JamFile::FromStream(std::move(ss));
+	ASSERT_TRUE(result.has_value());
+	ASSERT_EQ(0, result.value().Name.compare("empty"));
+	ASSERT_EQ(0u, result.value().Stations.size());
+	ASSERT_EQ(engine::Timer::QUANTISE_OFF, result.value().Quantisation);
+}
+
+TEST(JamFile, ToStream_RoundTrip_DoublesPrecision) {
+	// Verify that level/speed survive the ToStream→FromStream round-trip
+	// accurately regardless of the active locale.
+	JamFile::LoopTake take;
+	take.Name  = "take1";
+	take.Loops = { MakePanLoop("loop.wav", 1000, 0, 0.123456789, 0.987654321) };
+
+	JamFile::Station station;
+	station.Name        = "st";
+	station.StationType = 0;
+	station.LoopTakes   = { take };
+
+	JamFile jam;
+	jam.Version       = JamFile::VERSION_V;
+	jam.Name          = "precision";
+	jam.TimerTicks    = 0;
+	jam.QuantiseSamps = 0;
+	jam.Quantisation  = engine::Timer::QUANTISE_OFF;
+	jam.Stations      = { station };
+
+	std::stringstream ss;
+	ASSERT_TRUE(JamFile::ToStream(jam, ss));
+
+	auto result = JamFile::FromStream(std::move(ss));
+	ASSERT_TRUE(result.has_value());
+	const auto& lp = result.value().Stations[0].LoopTakes[0].Loops[0];
+	ASSERT_NEAR(0.123456789, lp.Level, 1e-9);
+	ASSERT_NEAR(0.987654321, lp.Speed, 1e-9);
+}


### PR DESCRIPTION
## Summary

Implements the export-session-to-directory feature described in `doc/plan-export-loops-to-wav.md`.

When the user presses **Ctrl+S**, Jamma:
1. Shows a native Windows folder-picker dialog (IFileOpenDialog)
2. Snapshots all active loop audio + metadata under `_audioMutex` (memory copies only, lock released before any I/O)
3. Writes one mono 16-bit PCM WAV file per active loop into the chosen directory
4. Serializes a `session.jam` JSON file alongside the WAVs containing the full session metadata

The `.jam` file is produced by a fully-implemented `JamFile::ToStream` (replaces the previous plain-text stub) and matches the schema that `JamFile::FromStream` already parses — ready for a future load-from-directory feature.

## Files changed

| File | Change |
|------|--------|
| `JammaLib/src/audio/AudioMixer.h` | Add `GetBehaviourParams()` accessor |
| `JammaLib/src/engine/Loop.h/.cpp` | Add `ExportSamples()` + `ToJamFile()` |
| `JammaLib/src/engine/LoopTake.h` | Add `GetLoops()` accessor |
| `JammaLib/src/engine/Station.h` | Add `GetLoopTakes()` accessor |
| `JammaLib/src/io/JamFile.cpp` | Replace `ToStream` stub with JSON serializer |
| `JammaLib/src/utils/PathUtils.h/.cpp` | Add `PickDirectory()` (Windows, COM RAII) |
| `JammaLib/src/engine/Scene.cpp` | Add Ctrl+S handler |

## Design notes

- All platform-specific code (IFileOpenDialog, COM init) lives exclusively in `PathUtils` — callers are platform-agnostic
- Audio lock is held only for the memory-copy snapshot phase; all file I/O happens after the lock is released
- Loading from the exported directory is **not** implemented in this PR but the file format is fully compatible with the existing loader
- `MuteGroups`, `SelectGroups`, and `StationType` are stored as 0 (engine does not yet track them)