### PR TITLE
feat: export session to directory on Ctrl+S

### DIFF
--- a/JammaLib/src/audio/AudioMixer.h
+++ b/JammaLib/src/audio/AudioMixer.h
@@ -235,6 +235,8 @@ namespace audio
 		double Level() const;
 		double UnmutedLevel() const;
 		void SetUnmutedLevel(double level);
+		BehaviourParams GetBehaviourParams() const
+			{ return _behaviour ? _behaviour->GetParams() : BehaviourParams{}; }
 		void WriteBlock(const std::shared_ptr<base::MultiAudioSink>& dest,
 			const float* srcBuf,
 			unsigned int numSamps);

--- a/JammaLib/src/engine/Loop.cpp
+++ b/JammaLib/src/engine/Loop.cpp
@@ -419,6 +419,55 @@ void Loop::SetMixerLevel(double level)
 	_mixer->SetUnmutedLevel(level);
 }
 
+std::vector<float> Loop::ExportSamples() const
+{
+	if (_loopLength == 0 || _playState == STATE_INACTIVE)
+		return {};
+
+	std::vector<float> out(_loopLength);
+	for (unsigned long i = 0; i < _loopLength; ++i)
+		out[i] = _bufferBank[constants::MaxLoopFadeSamps + i];
+	return out;
+}
+
+io::JamFile::Loop Loop::ToJamFile(const std::string& wavFilename) const
+{
+	io::JamFile::Loop s;
+	s.Name   = wavFilename;
+	s.Length = _loopLength;
+	s.Index  = (_playIndex >= constants::MaxLoopFadeSamps)
+	               ? _playIndex - constants::MaxLoopFadeSamps : 0ul;
+	s.MasterLoopCount = 0;
+	s.Level  = _mixer->UnmutedLevel();
+	s.Speed  = _pitch;
+	s.Muted  = IsMuted();
+	s.MuteGroups   = 0;
+	s.SelectGroups = 0;
+
+	auto params = _mixer->GetBehaviourParams();
+	if (auto* wire = std::get_if<audio::WireMixBehaviourParams>(&params))
+	{
+		s.Mix.Mix = io::JamFile::LoopMix::MIX_WIRE;
+		std::vector<unsigned long> chans;
+		for (auto c : wire->Channels) chans.push_back(static_cast<unsigned long>(c));
+		s.Mix.Params = chans;
+	}
+	else if (auto* pan = std::get_if<audio::PanMixBehaviourParams>(&params))
+	{
+		s.Mix.Mix = io::JamFile::LoopMix::MIX_PAN;
+		std::vector<double> levels;
+		for (auto l : pan->ChannelLevels) levels.push_back(static_cast<double>(l));
+		s.Mix.Params = levels;
+	}
+	else
+	{
+		s.Mix.Mix = io::JamFile::LoopMix::MIX_PAN;
+		s.Mix.Params = std::vector<double>{ 0.5, 0.5 };
+	}
+
+	return s;
+}
+
 bool Loop::Load(const io::WavReadWriter& readWriter)
 {
 	auto loadOpt = readWriter.Read(utils::DecodeUtf8(_loopParams.Wav), constants::MaxLoopBufferSize);

--- a/JammaLib/src/engine/Loop.h
+++ b/JammaLib/src/engine/Loop.h
@@ -179,6 +179,11 @@ namespace engine
 		std::string Id() const;
 		LoopPlayState PlayState() const { return _playState; }
 
+		// Returns the loop's audio samples for WAV export (empty if inactive).
+		std::vector<float> ExportSamples() const;
+		// Fills a JamFile::Loop struct from current engine state.
+		io::JamFile::Loop ToJamFile(const std::string& wavFilename) const;
+
 		void Update();
 		void SetMixerLevel(double level);
 		bool Load(const io::WavReadWriter& readWriter);

--- a/JammaLib/src/engine/LoopTake.h
+++ b/JammaLib/src/engine/LoopTake.h
@@ -117,6 +117,7 @@ namespace engine
 		std::string Id() const;
 		std::string SourceId() const;
 		LoopTakeSource TakeSourceType() const;
+		const std::vector<std::shared_ptr<Loop>>& GetLoops() const { return _loops; }
 		LoopTakeState TakeState() const;
 		unsigned long NumRecordedSamps() const;
 		std::shared_ptr<Loop> AddLoop(unsigned int chan, std::string stationName);

--- a/JammaLib/src/engine/Scene.cpp
+++ b/JammaLib/src/engine/Scene.cpp
@@ -1,5 +1,7 @@
 #include "Scene.h"
 #include "glm/ext.hpp"
+#include "../io/WavReadWriter.h"
+#include "../io/TextReadWriter.h"
 
 using namespace base;
 using namespace actions;
@@ -409,6 +411,126 @@ ActionResult Scene::OnAction(KeyAction action)
 		auto res = _undoHistory.Undo();
 
 		return { res };
+	}
+
+	// Ctrl+S — export session to directory
+	if ((83 == action.KeyChar)
+	 && (actions::KeyAction::KEY_UP == action.KeyActionType)
+	 && (Action::MODIFIER_CTRL & action.Modifiers))
+	{
+		auto exportDir = utils::PickDirectory(L"Choose export directory");
+		if (exportDir.empty())
+			return ActionResult::NoAction();
+
+		struct LoopSnapshot {
+			std::string        loopId;
+			std::vector<float> samples;
+			io::JamFile::Loop  jamLoop;
+		};
+		struct TakeSnapshot {
+			std::string               takeId;
+			std::vector<LoopSnapshot> loops;
+		};
+		struct StationSnapshot {
+			std::string               stationName;
+			unsigned int              stationType;
+			std::vector<TakeSnapshot> takes;
+		};
+
+		std::vector<StationSnapshot> stationSnapshots;
+		auto sampleRate = _audioDevice->GetAudioStreamParams().SampleRate;
+
+		{
+			std::lock_guard<std::mutex> lock(_audioMutex);
+
+			for (auto& station : _stations)
+			{
+				StationSnapshot ss;
+				ss.stationName = station->Name();
+				ss.stationType = 0;
+
+				for (auto& take : station->GetLoopTakes())
+				{
+					TakeSnapshot ts;
+					ts.takeId = take->Id();
+
+					for (auto& loop : take->GetLoops())
+					{
+						auto samples = loop->ExportSamples();
+						if (samples.empty())
+							continue;
+
+						auto wavFilename = loop->Id() + ".wav";
+						LoopSnapshot ls;
+						ls.loopId  = loop->Id();
+						ls.samples = std::move(samples);
+						ls.jamLoop = loop->ToJamFile(wavFilename);
+						ts.loops.push_back(std::move(ls));
+					}
+
+					if (!ts.loops.empty())
+						ss.takes.push_back(std::move(ts));
+				}
+
+				if (!ss.takes.empty())
+					stationSnapshots.push_back(std::move(ss));
+			}
+		}
+
+		if (stationSnapshots.empty())
+		{
+			std::cout << "Export: nothing to export" << std::endl;
+			return ActionResult::NoAction();
+		}
+
+		io::JamFile jam;
+		jam.Version       = io::JamFile::VERSION_V;
+		jam.Name          = "export";
+		jam.TimerTicks    = 0;
+		jam.QuantiseSamps = 0;
+		jam.Quantisation  = engine::Timer::QUANTISE_OFF;
+
+		for (auto& ss : stationSnapshots)
+		{
+			io::JamFile::Station st;
+			st.Name        = ss.stationName;
+			st.StationType = ss.stationType;
+
+			for (auto& ts : ss.takes)
+			{
+				io::JamFile::LoopTake take;
+				take.Name = ts.takeId;
+				for (auto& ls : ts.loops)
+					take.Loops.push_back(ls.jamLoop);
+				st.LoopTakes.push_back(std::move(take));
+			}
+			jam.Stations.push_back(std::move(st));
+		}
+
+		io::WavReadWriter wavWriter;
+		unsigned int wavCount = 0;
+		for (auto& ss : stationSnapshots)
+			for (auto& ts : ss.takes)
+				for (auto& ls : ts.loops)
+				{
+					auto path = exportDir + L"\\" + utils::DecodeUtf8(ls.jamLoop.Name);
+					if (wavWriter.Write(path, ls.samples,
+					                    static_cast<unsigned int>(ls.samples.size()),
+					                    sampleRate))
+						++wavCount;
+				}
+
+		std::stringstream jamStream;
+		io::JamFile::ToStream(jam, jamStream);
+
+		io::TextReadWriter textWriter;
+		auto jamPath = exportDir + L"\\session.jam";
+		textWriter.Write(jamPath, jamStream.str(), 0, 0);
+
+		std::cout << "Exported " << wavCount << " loop(s) + session.jam to "
+		          << utils::EncodeUtf8(exportDir) << std::endl;
+
+		return ActionResult::NoAction();
 	}
 
 	bool checkReset = false;

--- a/JammaLib/src/engine/Station.h
+++ b/JammaLib/src/engine/Station.h
@@ -95,6 +95,7 @@ namespace engine
 			std::optional<audio::AudioStreamParams> params) override;
 		virtual void Reset() override;
 		
+		const std::vector<std::shared_ptr<LoopTake>>& GetLoopTakes() const { return _loopTakes; }
 		std::shared_ptr<LoopTake> AddTake();
 		void AddTake(std::shared_ptr<LoopTake> take);
 		void AddTrigger(std::shared_ptr<Trigger> trigger);

--- a/JammaLib/src/io/JamFile.cpp
+++ b/JammaLib/src/io/JamFile.cpp
@@ -89,39 +89,88 @@ std::optional<JamFile> JamFile::FromStream(std::stringstream ss)
 
 bool JamFile::ToStream(JamFile jam, std::stringstream& ss)
 {
-	ss << "Version: " << jam.Version << std::endl;
-	ss << "Name: " << jam.Name << std::endl;
-	ss << "TimerTicks: " << jam.TimerTicks << std::endl;
-	ss << "QuantiseSamps: " << jam.QuantiseSamps << std::endl;
-	ss << "Quantisation: " << jam.Quantisation << std::endl;
+	auto quoted   = [](const std::string& s) { return "\"" + s + "\""; };
+	auto kvStr    = [&](const std::string& k, const std::string& v)
+	                    { return quoted(k) + ":" + quoted(v); };
+	auto kvUlong  = [&](const std::string& k, unsigned long v)
+	                    { return quoted(k) + ":" + std::to_string(v); };
+	auto kvDouble = [&](const std::string& k, double v)
+	                    { std::ostringstream o; o << v; return quoted(k) + ":" + o.str(); };
+	auto kvBool   = [&](const std::string& k, bool v)
+	                    { return quoted(k) + ":" + (v ? std::string("true") : std::string("false")); };
 
-	for (auto &station : jam.Stations)
-	{
-		ss << "=== Station ===" << std::endl;
-		ss << "Name: " << station.Name << std::endl;
-		ss << "StationType: " << station.StationType << std::endl;
+	auto quantStr = [](engine::Timer::QuantisationType q) -> std::string {
+		if (q == engine::Timer::QUANTISE_MULTIPLE) return "multiple";
+		if (q == engine::Timer::QUANTISE_POWER)    return "power";
+		return "off";
+	};
 
-		for (auto& loopTake : station.LoopTakes)
+	auto mixStr = [&](const JamFile::LoopMix& m) -> std::string {
+		std::string typeStr = (m.Mix == LoopMix::MIX_WIRE) ? "wire" : "pan";
+		std::string chans;
+		if (m.Mix == LoopMix::MIX_WIRE)
 		{
-			ss << "====== LoopTake ======" << std::endl;
-			ss << "Name: " << loopTake.Name << std::endl;
-
-			for (auto& loop: loopTake.Loops)
+			auto& v = std::get<std::vector<unsigned long>>(m.Params);
+			for (size_t i = 0; i < v.size(); ++i)
+				chans += (i ? "," : "") + std::to_string(v[i]);
+		}
+		else
+		{
+			auto& v = std::get<std::vector<double>>(m.Params);
+			for (size_t i = 0; i < v.size(); ++i)
 			{
-				ss << "========= Loop =========" << std::endl;
-				ss << "Name: " << loop.Name << std::endl;
-				ss << "Length: " << loop.Length << std::endl;
-				ss << "Index: " << loop.Index << std::endl;
-				ss << "MasterLoopCount: " << loop.MasterLoopCount << std::endl;
-				ss << "Level: " << loop.Level << std::endl;
-				ss << "Muted: " << loop.Muted << std::endl;
-				ss << "MixType: " << loop.Mix.Mix << std::endl;
-				ss << "MuteGroups: " << loop.MuteGroups << std::endl;
-				ss << "SelectGroups: " << loop.SelectGroups << std::endl;
+				std::ostringstream o;
+				o << v[i];
+				chans += (i ? "," : "") + o.str();
 			}
 		}
-	}
+		return "{" + kvStr("type", typeStr) + "," + quoted("chans") + ":[" + chans + "]}";
+	};
 
+	ss << "{";
+	ss << kvStr("name", jam.Name) << ",";
+	ss << kvUlong("timerticks", jam.TimerTicks) << ",";
+	ss << kvUlong("quantisesamps", jam.QuantiseSamps) << ",";
+	ss << kvStr("quantisation", quantStr(jam.Quantisation)) << ",";
+	ss << quoted("stations") << ":[";
+
+	for (size_t si = 0; si < jam.Stations.size(); ++si)
+	{
+		const auto& st = jam.Stations[si];
+		if (si) ss << ",";
+		ss << "{" << kvStr("name", st.Name) << ","
+		          << kvUlong("stationtype", st.StationType) << ","
+		          << quoted("takes") << ":[";
+
+		for (size_t ti = 0; ti < st.LoopTakes.size(); ++ti)
+		{
+			const auto& take = st.LoopTakes[ti];
+			if (ti) ss << ",";
+			ss << "{" << kvStr("name", take.Name) << ","
+			          << quoted("loops") << ":[";
+
+			for (size_t li = 0; li < take.Loops.size(); ++li)
+			{
+				const auto& lp = take.Loops[li];
+				if (li) ss << ",";
+				ss << "{"
+				   << kvStr("name",             lp.Name)               << ","
+				   << kvUlong("length",          lp.Length)             << ","
+				   << kvUlong("index",           lp.Index)              << ","
+				   << kvUlong("masterloopcount", lp.MasterLoopCount)    << ","
+				   << kvDouble("level",          lp.Level)              << ","
+				   << kvDouble("speed",          lp.Speed)              << ","
+				   << kvUlong("mutegroups",      lp.MuteGroups)         << ","
+				   << kvUlong("selectgroups",    lp.SelectGroups)       << ","
+				   << kvBool("muted",            lp.Muted)              << ","
+				   << quoted("mix") << ":" << mixStr(lp.Mix)
+				   << "}";
+			}
+			ss << "]}";
+		}
+		ss << "]}";
+	}
+	ss << "]}";
 	return true;
 }
 

--- a/JammaLib/src/utils/PathUtils.cpp
+++ b/JammaLib/src/utils/PathUtils.cpp
@@ -6,6 +6,7 @@
 ///////////////////////////////////////////////////////////
 
 #include <windows.h>
+#include <shobjidl_core.h>
 #include "PathUtils.h"
 
 std::wstring utils::GetPath(PathType pathType)
@@ -30,4 +31,36 @@ std::wstring utils::GetParentDirectory(std::wstring dir)
 {
 	std::filesystem::path p(dir);
 	return p.parent_path();
+}
+
+std::wstring utils::PickDirectory(const std::wstring& title)
+{
+	std::wstring result;
+	IFileOpenDialog* pfd = nullptr;
+
+	if (FAILED(CoCreateInstance(CLSID_FileOpenDialog, nullptr,
+		CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pfd))))
+		return result;
+
+	DWORD opts = 0;
+	pfd->GetOptions(&opts);
+	pfd->SetOptions(opts | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+	pfd->SetTitle(title.c_str());
+
+	if (SUCCEEDED(pfd->Show(nullptr)))
+	{
+		IShellItem* psi = nullptr;
+		if (SUCCEEDED(pfd->GetResult(&psi)))
+		{
+			PWSTR path = nullptr;
+			if (SUCCEEDED(psi->GetDisplayName(SIGDN_FILESYSPATH, &path)))
+			{
+				result = path;
+				CoTaskMemFree(path);
+			}
+			psi->Release();
+		}
+	}
+	pfd->Release();
+	return result;
 }

--- a/JammaLib/src/utils/PathUtils.h
+++ b/JammaLib/src/utils/PathUtils.h
@@ -21,4 +21,7 @@ namespace utils
 
 	std::wstring GetPath(PathType pathType);
 	std::wstring GetParentDirectory(std::wstring dir);
+	// Shows a native folder-picker dialog.
+	// Returns the chosen path, or an empty wstring if the user cancelled.
+	std::wstring PickDirectory(const std::wstring& title = L"Choose export directory");
 }


### PR DESCRIPTION
- Add AudioMixer::GetBehaviourParams() to expose mix config
- Add Loop::ExportSamples() and Loop::ToJamFile() for WAV export
- Add LoopTake::GetLoops() and Station::GetLoopTakes() accessors
- Implement JamFile::ToStream() as proper JSON serializer
- Add PathUtils::PickDirectory() using IFileOpenDialog (COM)
- Handle Ctrl+S in Scene: pick dir, snapshot active loops under mutex, write one WAV per loop + session .jam JSON metadata