### PR TITLE
Bugfix/gl threading

### DIFF
--- a/JammaLib/JammaLib.vcxproj
+++ b/JammaLib/JammaLib.vcxproj
@@ -450,6 +450,8 @@
     <ClCompile Include="src\midi\MidiNote.cpp" />
     <ClCompile Include="src\midi\MidiQuantisation.cpp" />
     <ClCompile Include="src\midi\MidiTimestampMapper.cpp" />
+    <ClCompile Include="src\midi\MidiIndexedOutputSink.cpp" />
+    <ClCompile Include="src\midi\MidiVstOutputSink.cpp" />
     <ClCompile Include="src\graphics\MidiModel.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/JammaLib/JammaLib.vcxproj.filters
+++ b/JammaLib/JammaLib.vcxproj.filters
@@ -314,6 +314,12 @@
     <ClInclude Include="src\midi\MidiTimestampMapper.h">
       <Filter>src\midi</Filter>
     </ClInclude>
+    <ClInclude Include="src\midi\MidiIndexedOutputSink.h">
+      <Filter>src\midi</Filter>
+    </ClInclude>
+    <ClInclude Include="src\midi\MidiVstOutputSink.h">
+      <Filter>src\midi</Filter>
+    </ClInclude>
     <ClInclude Include="src\graphics\MidiModel.h">
       <Filter>src\graphics</Filter>
     </ClInclude>
@@ -641,6 +647,12 @@
       <Filter>src\midi</Filter>
     </ClCompile>
     <ClCompile Include="src\midi\MidiTimestampMapper.cpp">
+      <Filter>src\midi</Filter>
+    </ClCompile>
+    <ClCompile Include="src\midi\MidiIndexedOutputSink.cpp">
+      <Filter>src\midi</Filter>
+    </ClCompile>
+    <ClCompile Include="src\midi\MidiVstOutputSink.cpp">
       <Filter>src\midi</Filter>
     </ClCompile>
     <ClCompile Include="src\graphics\MidiModel.cpp">

--- a/JammaLib/src/engine/LoopTake.cpp
+++ b/JammaLib/src/engine/LoopTake.cpp
@@ -352,8 +352,8 @@ void LoopTake::Zero(unsigned int numSamps,
 			channel->Zero(numSamps);
 	}
 
-	for (auto& loop : state->Loops)
-		loop->Zero(numSamps);
+	for (const auto& weakLoop : state->Loops)
+		if (auto loop = weakLoop.lock()) loop->Zero(numSamps);
 }
 
 // Only called when outputting to DAC
@@ -376,11 +376,9 @@ void LoopTake::WriteBlock(const std::shared_ptr<MultiAudioSink> dest,
 	if (!state)
 		return;
 
-	for (const auto& loop : state->Loops)
-		loop->WriteBlock(loopDest,
-			trigger,
-			indexOffset,
-			numSamps);
+	for (const auto& weakLoop : state->Loops)
+		if (auto loop = weakLoop.lock())
+			loop->WriteBlock(loopDest, trigger, indexOffset, numSamps);
 
 	if (nullptr != trigger)
 		return;
@@ -446,8 +444,8 @@ void LoopTake::EndMultiPlay(unsigned int numSamps)
 	if (!state)
 		return;
 
-	for (auto& loop : state->Loops)
-		loop->EndMultiPlay(numSamps);
+	for (const auto& weakLoop : state->Loops)
+		if (auto loop = weakLoop.lock()) loop->EndMultiPlay(numSamps);
 
 	for (auto& buffer : state->AudioBuffers)
 	{
@@ -482,8 +480,8 @@ void LoopTake::EndMultiWrite(unsigned int numSamps,
 	if (!audioState)
 		return;
 
-	for (auto& loop : audioState->Loops)
-		 loop->EndWrite(numSamps, updateIndex);
+	for (const auto& weakLoop : audioState->Loops)
+		if (auto loop = weakLoop.lock()) loop->EndWrite(numSamps, updateIndex);
 
 	auto isRecording = IsArmed();
 	auto takeState = _state.load(std::memory_order_acquire);
@@ -1836,7 +1834,7 @@ const std::shared_ptr<AudioSink> LoopTake::_InputChannel(unsigned int channel,
 	case Audible::AUDIOSOURCE_MONITOR:
 	case Audible::AUDIOSOURCE_BOUNCE:
 		if (channel < loops.size())
-			return loops[channel];
+			return loops[channel].lock();
 
 		break;
 	case Audible::AUDIOSOURCE_LOOPS:
@@ -1862,7 +1860,9 @@ std::shared_ptr<const LoopTake::AudioState> LoopTake::_AudioStateSnapshot() cons
 void LoopTake::_PublishAudioState()
 {
 	auto state = std::make_shared<AudioState>();
-	state->Loops = _loops;
+	state->Loops.reserve(_loops.size());
+	for (const auto& loop : _loops)
+		state->Loops.push_back(loop);
 	state->AudioMixers = _audioMixers;
 	state->AudioBuffers = _audioBuffers;
 	state->VstBlockScratch.resize(state->AudioBuffers.size() * constants::MaxBlockSize);

--- a/JammaLib/src/engine/LoopTake.cpp
+++ b/JammaLib/src/engine/LoopTake.cpp
@@ -6,6 +6,7 @@
 
 #include "../graphics/MidiModel.h"
 #include "../midi/MidiNote.h"
+#include "../midi/MidiIndexedOutputSink.h"
 
 namespace
 {
@@ -1205,34 +1206,6 @@ unsigned int LoopTake::ReadMidiBlock(std::uint32_t globalSample,
 	midi::IMidiOutputSink& sink,
 	unsigned int firstOutputIndex) noexcept
 {
-	class IndexedMidiSink final : public midi::IMidiSink
-	{
-	public:
-		IndexedMidiSink(midi::IMidiOutputSink& outputSink,
-			unsigned int outputIndex,
-			std::uint32_t midiBlockStart,
-			std::uint32_t outputBlockStart) noexcept :
-			_outputSink(outputSink),
-			_outputIndex(outputIndex),
-			_midiBlockStart(midiBlockStart),
-			_outputBlockStart(outputBlockStart)
-		{
-		}
-
-		void OnEvent(const midi::MidiEvent& ev) noexcept override
-		{
-			midi::MidiEvent mapped = ev;
-			mapped.sampleOffset = _outputBlockStart + (ev.sampleOffset - _midiBlockStart);
-			_outputSink.OnEvent(_outputIndex, mapped);
-		}
-
-	private:
-		midi::IMidiOutputSink& _outputSink;
-		unsigned int _outputIndex;
-		std::uint32_t _midiBlockStart;
-		std::uint32_t _outputBlockStart;
-	};
-
 	if (IsMuted())
 		return static_cast<unsigned int>(_midiLoops.size());
 
@@ -1243,7 +1216,7 @@ unsigned int LoopTake::ReadMidiBlock(std::uint32_t globalSample,
 		if (!_midiLoops[i])
 			continue;
 
-		IndexedMidiSink indexedSink(sink, firstOutputIndex + i, midiBlockStart, globalSample);
+		midi::MidiIndexedOutputSink indexedSink(sink, firstOutputIndex + i, midiBlockStart, globalSample);
 		_midiLoops[i]->ReadBlock(midiBlockStart, numSamples, indexedSink);
 	}
 

--- a/JammaLib/src/engine/LoopTake.h
+++ b/JammaLib/src/engine/LoopTake.h
@@ -217,7 +217,8 @@ namespace engine
 
 		struct AudioState
 		{
-			std::vector<std::shared_ptr<Loop>> Loops;
+			// weak_ptr: AudioState destruction on any thread won't trigger GL destructors
+			std::vector<std::weak_ptr<Loop>> Loops;
 			std::vector<std::shared_ptr<audio::AudioMixer>> AudioMixers;
 			std::vector<std::shared_ptr<audio::AudioBuffer>> AudioBuffers;
 			std::vector<float> VstBlockScratch;

--- a/JammaLib/src/engine/NinjamSession.cpp
+++ b/JammaLib/src/engine/NinjamSession.cpp
@@ -429,7 +429,7 @@ void NinjamSession::Stop()
 
 void NinjamSession::SendChat(const std::string& msg)
 {
-	ConnectionUse conn(*this);
+	NinjamConnectionUse conn(*this);
 	if (conn && conn->IsConnected())
 	{
 		conn->SendChat(msg);
@@ -443,13 +443,13 @@ void NinjamSession::SendChat(const std::string& msg)
 
 bool NinjamSession::IsConnected() const noexcept
 {
-	ConnectionUse conn(*this);
+	NinjamConnectionUse conn(*this);
 	return conn && conn->IsConnected();
 }
 
 std::optional<io::NinjamRemoteSnapshot> NinjamSession::Pump()
 {
-	ConnectionUse conn(*this);
+	NinjamConnectionUse conn(*this);
 	if (!conn)
 		return std::nullopt;
 
@@ -471,7 +471,7 @@ void NinjamSession::SetAudioFormat(unsigned int sampleRate,
 	_audioNumInputChannels = numInputChannels;
 	_audioNumOutputChannels = numOutputChannels;
 
-	ConnectionUse conn(*this);
+	NinjamConnectionUse conn(*this);
 	if (conn)
 		conn->SetAudioFormat(sampleRate, blockSize, numInputChannels, numOutputChannels);
 }
@@ -480,7 +480,7 @@ void NinjamSession::ProcessAudioBlock(const float* interleavedInput,
 	unsigned int numFrames,
 	unsigned int sampleRate)
 {
-	ConnectionUse conn(*this);
+	NinjamConnectionUse conn(*this);
 	if (conn)
 		conn->ProcessAudioBlock(interleavedInput, numFrames, sampleRate);
 }
@@ -490,7 +490,7 @@ bool NinjamSession::ConsumeStereoPair(unsigned int outChannelLeft,
 	const float*& right,
 	unsigned int& numFrames) const
 {
-	ConnectionUse conn(*this);
+	NinjamConnectionUse conn(*this);
 	if (!conn)
 		return false;
 
@@ -499,7 +499,7 @@ bool NinjamSession::ConsumeStereoPair(unsigned int outChannelLeft,
 
 bool NinjamSession::RequestServerTempo(float bpm, int bpi)
 {
-	ConnectionUse conn(*this);
+	NinjamConnectionUse conn(*this);
 	if (!conn || !conn->IsConnected())
 		return false;
 

--- a/JammaLib/src/engine/NinjamSession.h
+++ b/JammaLib/src/engine/NinjamSession.h
@@ -14,6 +14,32 @@
 
 namespace engine
 {
+	class NinjamSession;
+
+	class NinjamConnectionUse
+	{
+	public:
+		explicit NinjamConnectionUse(const NinjamSession& session) noexcept;
+		~NinjamConnectionUse();
+
+		NinjamConnectionUse(const NinjamConnectionUse&) = delete;
+		NinjamConnectionUse& operator=(const NinjamConnectionUse&) = delete;
+
+		io::NinjamConnection* operator->() const noexcept
+		{
+			return _connection;
+		}
+
+		explicit operator bool() const noexcept
+		{
+			return _connection != nullptr;
+		}
+
+	private:
+		const NinjamSession& _session;
+		io::NinjamConnection* _connection = nullptr;
+	};
+
 	// Owns a NinjamConnection and manages all ninjam-specific lifecycle so
 	// that Scene stays free of those concerns.
 	// Chat I/O is driven externally: the caller sends messages via SendChat()
@@ -93,37 +119,7 @@ namespace engine
 		static std::string FormatPublicServerSummary(const PublicServerInfo& server);
 
 	private:
-		class ConnectionUse
-		{
-		public:
-			explicit ConnectionUse(const NinjamSession& session) noexcept
-				: _session(session), _connection(session._AcquireConnectionUse())
-			{
-			}
-
-			~ConnectionUse()
-			{
-				if (_connection)
-					_session._ReleaseConnectionUse();
-			}
-
-			ConnectionUse(const ConnectionUse&) = delete;
-			ConnectionUse& operator=(const ConnectionUse&) = delete;
-
-			io::NinjamConnection* operator->() const noexcept
-			{
-				return _connection;
-			}
-
-			explicit operator bool() const noexcept
-			{
-				return _connection != nullptr;
-			}
-
-		private:
-			const NinjamSession& _session;
-			io::NinjamConnection* _connection = nullptr;
-		};
+		friend class NinjamConnectionUse;
 
 		static const std::array<const char*, 17> _StaticServerHosts;
 		static constexpr auto _ServerListFetchTtl = std::chrono::seconds(30);
@@ -155,4 +151,15 @@ namespace engine
 		std::atomic_uint _audioNumInputChannels{ 0u };
 		std::atomic_uint _audioNumOutputChannels{ 0u };
 	};
+
+	inline NinjamConnectionUse::NinjamConnectionUse(const NinjamSession& session) noexcept
+		: _session(session), _connection(session._AcquireConnectionUse())
+	{
+	}
+
+	inline NinjamConnectionUse::~NinjamConnectionUse()
+	{
+		if (_connection)
+			_session._ReleaseConnectionUse();
+	}
 }

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -324,29 +324,6 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 	auto state = _AudioStateSnapshot();
 	if (!state)
 		return;
-
-	class StationMidiSink final : public IMidiOutputSink
-	{
-	public:
-		StationMidiSink(Station& station,
-			vst::VstChain* chain,
-			const MidiVstRoutingSnapshot* routes) noexcept :
-			_station(station),
-			_chain(chain),
-			_routes(routes)
-		{
-		}
-
-		void OnEvent(unsigned int outputIndex, const MidiEvent& event) noexcept override
-		{
-			_station._SendMidiToVstChain(_chain, _routes, event, false, outputIndex);
-		}
-
-	private:
-		Station& _station;
-		vst::VstChain* _chain;
-		const MidiVstRoutingSnapshot* _routes;
-	};
 	auto stationSink = std::dynamic_pointer_cast<MultiAudioSink>(ptr);
 	for (const auto& weakTake : state->LoopTakes)
 	{
@@ -389,13 +366,13 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 	while (_liveMidiIngress.Pop(liveMidi))
 	{
 		if (vstActive)
-			_SendMidiToVstChain(chain.get(), routes, liveMidi, true, LiveMidiOutputIndex);
+			midi::SendMidiToVstChain(chain.get(), routes, liveMidi, true, LiveMidiOutputIndex);
 	}
 
 	auto midiOutputIndex = 0u;
 	if (vstActive)
 	{
-		StationMidiSink midiSink(*this, chain.get(), routes);
+		midi::MidiVstOutputSink midiSink(chain.get(), routes);
 		for (const auto& weakTake : state->LoopTakes)
 		{
 			auto take = weakTake.lock();
@@ -1566,31 +1543,6 @@ void Station::_WireVuSliders()
 		if (slider)
 			slider->SetMixer(_audioMixers[i]);
 	}
-}
-
-void Station::_SendMidiToVstChain(vst::VstChain* chain,
-	const MidiVstRoutingSnapshot* routes,
-	const MidiEvent& event,
-	bool isRealtime,
-	unsigned int midiOutputIndex) noexcept
-{
-	if (!chain)
-		return;
-
-	if (!routes || !routes->HasRoutes())
-	{
-		chain->SendMidiEvent(event, isRealtime);
-		return;
-	}
-
-	const auto pluginIndex = routes->PluginForOutput(midiOutputIndex);
-	if (pluginIndex != MidiVstRoutingSnapshot::NoPlugin && pluginIndex < chain->NumPlugins())
-	{
-		chain->SendMidiEventToPlugin(pluginIndex, event, isRealtime);
-		return;
-	}
-
-	chain->SendMidiEvent(event, isRealtime);
 }
 
 void Station::_DitchLoopTake(std::shared_ptr<LoopTake>& take) noexcept

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -347,21 +347,12 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 		vst::VstChain* _chain;
 		const MidiVstRoutingSnapshot* _routes;
 	};
-
-	for (const auto& weakTake : state->LoopTakes)
-		if (auto take = weakTake.lock())
-			take->WriteBlock(std::dynamic_pointer_cast<MultiAudioSink>(ptr), trigger, indexOffset, numSamps);
+	auto stationSink = std::dynamic_pointer_cast<MultiAudioSink>(ptr);
 
 	auto sampsToRead = (numSamps <= constants::MaxBlockSize) ? numSamps : constants::MaxBlockSize;
 	auto masterLevel = static_cast<float>(_masterMixer->Level());
 	auto masterPeak = 0.0f;
 	const auto channelCount = (state->AudioBuffers.size() < state->AudioMixers.size()) ? state->AudioBuffers.size() : state->AudioMixers.size();
-	if (channelCount == 0u)
-	{
-		_masterMixer->UpdateVu(0.0f, sampsToRead);
-		_masterMixer->Offset(sampsToRead);
-		return;
-	}
 
 	for (auto i = 0u; i < channelCount; i++)
 	{
@@ -381,7 +372,7 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 
 	auto chain = _vstChain.load(std::memory_order_acquire);
 	const auto* routes = _midiVstRoutes.load(std::memory_order_acquire);
-	const bool vstActive = chain && chain->IsActive() && (state->VstBlockPtrs.size() >= channelCount);
+	const bool vstActive = (channelCount > 0u) && chain && chain->IsActive() && (state->VstBlockPtrs.size() >= channelCount);
 	if (vstActive)
 		chain->BeginMidiBlock(blockStartSample, sampsToRead);
 
@@ -393,14 +384,28 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 			_SendMidiToVstChain(chain.get(), routes, liveMidi, true, LiveMidiOutputIndex);
 	}
 
+	auto midiOutputIndex = 0u;
+	StationMidiSink midiSink(*this, chain.get(), routes);
+	for (const auto& weakTake : state->LoopTakes)
+	{
+		auto take = weakTake.lock();
+		if (!take)
+			continue;
+
+		take->WriteBlock(stationSink, trigger, indexOffset, numSamps);
+		if (vstActive)
+			midiOutputIndex += take->ReadMidiBlock(blockStartSample, sampsToRead, midiSink, midiOutputIndex);
+	}
+
+	if (channelCount == 0u)
+	{
+		_masterMixer->UpdateVu(0.0f, sampsToRead);
+		_masterMixer->Offset(sampsToRead);
+		return;
+	}
+
 	if (vstActive)
 	{
-		StationMidiSink midiSink(*this, chain.get(), routes);
-		auto midiOutputIndex = 0u;
-		for (const auto& weakTake : state->LoopTakes)
-			if (auto take = weakTake.lock())
-				midiOutputIndex += take->ReadMidiBlock(blockStartSample, sampsToRead, midiSink, midiOutputIndex);
-
 		chain->ProcessBlockMulti(state->VstBlockPtrs.data(), static_cast<int>(channelCount), sampsToRead);
 	}
 

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -385,16 +385,29 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 	}
 
 	auto midiOutputIndex = 0u;
-	StationMidiSink midiSink(*this, chain.get(), routes);
-	for (const auto& weakTake : state->LoopTakes)
+	if (vstActive)
 	{
-		auto take = weakTake.lock();
-		if (!take)
-			continue;
+		StationMidiSink midiSink(*this, chain.get(), routes);
+		for (const auto& weakTake : state->LoopTakes)
+		{
+			auto take = weakTake.lock();
+			if (!take)
+				continue;
 
-		take->WriteBlock(stationSink, trigger, indexOffset, numSamps);
-		if (vstActive)
+			take->WriteBlock(stationSink, trigger, indexOffset, numSamps);
 			midiOutputIndex += take->ReadMidiBlock(blockStartSample, sampsToRead, midiSink, midiOutputIndex);
+		}
+	}
+	else
+	{
+		for (const auto& weakTake : state->LoopTakes)
+		{
+			auto take = weakTake.lock();
+			if (!take)
+				continue;
+
+			take->WriteBlock(stationSink, trigger, indexOffset, numSamps);
+		}
 	}
 
 	if (channelCount == 0u)

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -348,6 +348,14 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 		const MidiVstRoutingSnapshot* _routes;
 	};
 	auto stationSink = std::dynamic_pointer_cast<MultiAudioSink>(ptr);
+	for (const auto& weakTake : state->LoopTakes)
+	{
+		auto take = weakTake.lock();
+		if (!take)
+			continue;
+
+		take->WriteBlock(stationSink, trigger, indexOffset, numSamps);
+	}
 
 	auto sampsToRead = (numSamps <= constants::MaxBlockSize) ? numSamps : constants::MaxBlockSize;
 	auto masterLevel = static_cast<float>(_masterMixer->Level());
@@ -393,20 +401,7 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 			auto take = weakTake.lock();
 			if (!take)
 				continue;
-
-			take->WriteBlock(stationSink, trigger, indexOffset, numSamps);
 			midiOutputIndex += take->ReadMidiBlock(blockStartSample, sampsToRead, midiSink, midiOutputIndex);
-		}
-	}
-	else
-	{
-		for (const auto& weakTake : state->LoopTakes)
-		{
-			auto take = weakTake.lock();
-			if (!take)
-				continue;
-
-			take->WriteBlock(stationSink, trigger, indexOffset, numSamps);
 		}
 	}
 

--- a/JammaLib/src/engine/Station.cpp
+++ b/JammaLib/src/engine/Station.cpp
@@ -309,8 +309,8 @@ void Station::Zero(unsigned int numSamps,
 		}
 	}
 
-	for (auto& take : state->LoopTakes)
-		take->Zero(numSamps, source);
+	for (const auto& weakTake : state->LoopTakes)
+		if (auto take = weakTake.lock()) take->Zero(numSamps, source);
 }
 
 // Only called when outputting to DAC
@@ -348,11 +348,9 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 		const MidiVstRoutingSnapshot* _routes;
 	};
 
-	for (const auto& take : state->LoopTakes)
-		take->WriteBlock(std::dynamic_pointer_cast<MultiAudioSink>(ptr),
-			trigger,
-			indexOffset,
-			numSamps);
+	for (const auto& weakTake : state->LoopTakes)
+		if (auto take = weakTake.lock())
+			take->WriteBlock(std::dynamic_pointer_cast<MultiAudioSink>(ptr), trigger, indexOffset, numSamps);
 
 	auto sampsToRead = (numSamps <= constants::MaxBlockSize) ? numSamps : constants::MaxBlockSize;
 	auto masterLevel = static_cast<float>(_masterMixer->Level());
@@ -399,8 +397,9 @@ void Station::WriteBlock(const std::shared_ptr<base::MultiAudioSink> dest,
 	{
 		StationMidiSink midiSink(*this, chain.get(), routes);
 		auto midiOutputIndex = 0u;
-		for (const auto& take : state->LoopTakes)
-			midiOutputIndex += take->ReadMidiBlock(blockStartSample, sampsToRead, midiSink, midiOutputIndex);
+		for (const auto& weakTake : state->LoopTakes)
+			if (auto take = weakTake.lock())
+				midiOutputIndex += take->ReadMidiBlock(blockStartSample, sampsToRead, midiSink, midiOutputIndex);
 
 		chain->ProcessBlockMulti(state->VstBlockPtrs.data(), static_cast<int>(channelCount), sampsToRead);
 	}
@@ -428,8 +427,8 @@ void Station::EndMultiPlay(unsigned int numSamps)
 	if (!state)
 		return;
 
-	for (auto& take : state->LoopTakes)
-		take->EndMultiPlay(numSamps);
+	for (const auto& weakTake : state->LoopTakes)
+		if (auto take = weakTake.lock()) take->EndMultiPlay(numSamps);
 
 	for (auto& buffer : state->AudioBuffers)
 	{
@@ -458,8 +457,8 @@ void Station::OnBlockWriteChannel(unsigned int channel,
 			if (!state)
 				break;
 
-			for (auto& take : state->LoopTakes)
-			take->OnBlockWriteChannel(channel, request, writeOffset);
+			for (const auto& weakTake : state->LoopTakes)
+				if (auto take = weakTake.lock()) take->OnBlockWriteChannel(channel, request, writeOffset);
 		}
 		break;
 	}
@@ -473,8 +472,8 @@ void Station::EndMultiWrite(unsigned int numSamps,
 	if (!state)
 		return;
 
-	for (auto& take : state->LoopTakes)
-		take->EndMultiWrite(numSamps, updateIndex, source);
+	for (const auto& weakTake : state->LoopTakes)
+		if (auto take = weakTake.lock()) take->EndMultiWrite(numSamps, updateIndex, source);
 }
 
 void Station::SetSelectDepth(base::SelectDepth depth)
@@ -1181,14 +1180,17 @@ void Station::OnBounce(unsigned int numSamps,
 			std::string targetId = take.TargetTakeId;
 			auto sourceMatch = std::find_if(state->LoopTakes.begin(),
 				state->LoopTakes.end(),
-				[&sourceId](const std::shared_ptr<LoopTake>& arg) { return arg->Id() == sourceId; });
+				[&sourceId](const std::weak_ptr<LoopTake>& arg) { auto t = arg.lock(); return t && t->Id() == sourceId; });
 			auto targetMatch = std::find_if(state->LoopTakes.begin(),
 				state->LoopTakes.end(),
-				[&targetId](const std::shared_ptr<LoopTake>& arg) { return arg->Id() == targetId; });
+				[&targetId](const std::weak_ptr<LoopTake>& arg) { auto t = arg.lock(); return t && t->Id() == targetId; });
 
 			if ((state->LoopTakes.end() != sourceMatch) && (state->LoopTakes.end() != targetMatch))
 			{
-				(*sourceMatch)->WriteBlock(*targetMatch, trigger, sourceOffset, numSamps);
+				auto sourceTake = sourceMatch->lock();
+				auto targetTake = targetMatch->lock();
+				if (sourceTake && targetTake)
+					sourceTake->WriteBlock(targetTake, trigger, sourceOffset, numSamps);
 			}
 		}
 	}
@@ -1460,7 +1462,9 @@ std::shared_ptr<const Station::AudioState> Station::_AudioStateSnapshot() const
 void Station::_PublishAudioState()
 {
 	auto state = std::make_shared<AudioState>();
-	state->LoopTakes = _loopTakes;
+	state->LoopTakes.reserve(_loopTakes.size());
+	for (const auto& take : _loopTakes)
+		state->LoopTakes.push_back(take);
 	state->AudioMixers = _audioMixers;
 	state->AudioBuffers = _audioBuffers;
 	state->VstBlockScratch.resize(state->AudioBuffers.size() * constants::MaxBlockSize);

--- a/JammaLib/src/engine/Station.h
+++ b/JammaLib/src/engine/Station.h
@@ -17,6 +17,7 @@
 #include "../gui/GuiRack.h"
 #include "../io/InitFile.h"
 #include "../midi/MidiQueue.h"
+#include "../midi/MidiVstOutputSink.h"
 #include "../vst/VstChain.h"
 
 namespace engine
@@ -62,7 +63,7 @@ namespace engine
 			STATIONPANEL_ROUTER
 		};
 
-		static constexpr unsigned int LiveMidiOutputIndex = ~0u;
+		static constexpr unsigned int LiveMidiOutputIndex = midi::LiveMidiOutputIndex;
 
 	public:
 		Station(StationParams params,
@@ -216,40 +217,7 @@ namespace engine
 		gui::GuiRackParams _GetRackParams(utils::Size2d size);
 		std::optional<std::shared_ptr<LoopTake>> _TryGetTake(std::string id);
 		void _WireVuSliders();
-		struct MidiVstRoutingSnapshot
-		{
-			static constexpr size_t NoPlugin = (std::numeric_limits<size_t>::max)();
-
-			std::vector<size_t> PluginByMidiOutput;
-			size_t LivePlugin = NoPlugin;
-
-			bool HasRoutes() const noexcept
-			{
-				if (LivePlugin != NoPlugin)
-					return true;
-				for (const auto pluginIndex : PluginByMidiOutput)
-				{
-					if (pluginIndex != NoPlugin)
-						return true;
-				}
-				return false;
-			}
-
-			size_t PluginForOutput(unsigned int midiOutputIndex) const noexcept
-			{
-				if (midiOutputIndex == LiveMidiOutputIndex)
-					return LivePlugin;
-				if (midiOutputIndex < PluginByMidiOutput.size())
-					return PluginByMidiOutput[midiOutputIndex];
-				return NoPlugin;
-			}
-		};
-
-		void _SendMidiToVstChain(vst::VstChain* chain,
-			const MidiVstRoutingSnapshot* routes,
-			const midi::MidiEvent& event,
-			bool isRealtime,
-			unsigned int midiOutputIndex) noexcept;
+		using MidiVstRoutingSnapshot = midi::MidiVstRoutingSnapshot;
 		// Enqueue NoteOffs for any held MIDI notes then call Ditch().
 		// Must be called from the action thread; NoteOffs are delivered via EnqueueLiveMidiEvent.
 		void _DitchLoopTake(std::shared_ptr<LoopTake>& take) noexcept;

--- a/JammaLib/src/engine/Station.h
+++ b/JammaLib/src/engine/Station.h
@@ -200,7 +200,8 @@ namespace engine
 
 		struct AudioState
 		{
-			std::vector<std::shared_ptr<LoopTake>> LoopTakes;
+			// weak_ptr: AudioState destruction on any thread won't trigger GL destructors
+			std::vector<std::weak_ptr<LoopTake>> LoopTakes;
 			std::vector<std::shared_ptr<audio::AudioMixer>> AudioMixers;
 			std::vector<std::shared_ptr<audio::AudioBuffer>> AudioBuffers;
 			std::vector<float> VstBlockScratch;

--- a/JammaLib/src/graphics/Font.cpp
+++ b/JammaLib/src/graphics/Font.cpp
@@ -167,7 +167,7 @@ GLuint Font::InitVertexArray(const std::string& str, GLenum usage, GLuint* outPo
 	glGenVertexArrays(1, &vao);
 	glBindVertexArray(vao);
 
-	GLuint vbo[2] = {};
+	GLuint vbo[2];
 	glGenBuffers(2, vbo);
 
 	auto numChars = str.size();

--- a/JammaLib/src/graphics/Font.cpp
+++ b/JammaLib/src/graphics/Font.cpp
@@ -143,7 +143,7 @@ std::string Font::GetFontName(FontOptions::FontSize size)
 	return "";
 }
 
-GLuint Font::InitVertexArray(const std::string& str, GLenum usage)
+GLuint Font::InitVertexArray(const std::string& str, GLenum usage, GLuint* outPosBuffer, GLuint* outUvBuffer)
 {
 	if (0 == _params.NumWidth)
 		return 0;
@@ -167,7 +167,7 @@ GLuint Font::InitVertexArray(const std::string& str, GLenum usage)
 	glGenVertexArrays(1, &vao);
 	glBindVertexArray(vao);
 
-	GLuint vbo[2];
+	GLuint vbo[2] = {};
 	glGenBuffers(2, vbo);
 
 	auto numChars = str.size();
@@ -183,17 +183,22 @@ GLuint Font::InitVertexArray(const std::string& str, GLenum usage)
 	}
 
 	glBindBuffer(GL_ARRAY_BUFFER, vbo[0]);
-	glBufferData(GL_ARRAY_BUFFER, pos.size() * sizeof(GLfloat), pos.data(), GL_STATIC_DRAW);
+	glBufferData(GL_ARRAY_BUFFER, pos.size() * sizeof(GLfloat), pos.data(), usage);
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, 0);
 	glEnableVertexAttribArray(0);
 
 	glBindBuffer(GL_ARRAY_BUFFER, vbo[1]);
-	glBufferData(GL_ARRAY_BUFFER, uv.size() * sizeof(GLfloat), uv.data(), GL_STATIC_DRAW);
+	glBufferData(GL_ARRAY_BUFFER, uv.size() * sizeof(GLfloat), uv.data(), usage);
 	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, 0);
 	glEnableVertexAttribArray(1);
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindVertexArray(0);
+
+	if (outPosBuffer)
+		*outPosBuffer = vbo[0];
+	if (outUvBuffer)
+		*outUvBuffer = vbo[1];
 
 	utils::GlUtils::CheckError("Font::InitVertexArray");
 

--- a/JammaLib/src/graphics/Font.h
+++ b/JammaLib/src/graphics/Font.h
@@ -106,7 +106,7 @@ namespace graphics
 			return *this;
 		}
 
-		GLuint InitVertexArray(const std::string& str, GLenum usage);
+		GLuint InitVertexArray(const std::string& str, GLenum usage, GLuint* outPosBuffer = nullptr, GLuint* outUvBuffer = nullptr);
 		void Draw(GlDrawContext& ctx, GLuint vertexArray, unsigned int numChars);
 		float MeasureString(const std::string& str) const;
 		float GetHeight() const;

--- a/JammaLib/src/graphics/GlDeleteQueue.h
+++ b/JammaLib/src/graphics/GlDeleteQueue.h
@@ -43,18 +43,32 @@ namespace graphics::GlDeleteQueue
 
 	inline void SetRenderThread(std::thread::id id) noexcept
 	{
-		std::lock_guard<std::mutex> lock(_Mutex());
-		_RenderThreadId() = id;
+		try
+		{
+			std::lock_guard<std::mutex> lock(_Mutex());
+			_RenderThreadId() = id;
+		}
+		catch (...)
+		{
+			// Best-effort: if locking fails, leave render thread unset.
+		}
 	}
 
 	inline bool IsRenderThread() noexcept
 	{
-		std::lock_guard<std::mutex> lock(_Mutex());
-		auto renderThread = _RenderThreadId();
-		if (renderThread == std::thread::id())
-			return false;
+		try
+		{
+			std::lock_guard<std::mutex> lock(_Mutex());
+			auto renderThread = _RenderThreadId();
+			if (renderThread == std::thread::id())
+				return false;
 
-		return std::this_thread::get_id() == renderThread;
+			return std::this_thread::get_id() == renderThread;
+		}
+		catch (...)
+		{
+			return false;
+		}
 	}
 
 	inline std::vector<GLuint> _FilterIds(GLsizei n, const GLuint* ids)

--- a/JammaLib/src/graphics/GlDeleteQueue.h
+++ b/JammaLib/src/graphics/GlDeleteQueue.h
@@ -102,25 +102,32 @@ namespace graphics::GlDeleteQueue
 		}
 	}
 
-	inline void _DeleteOrQueue(DeleteKind kind, GLsizei n, const GLuint* ids)
+	inline void _DeleteOrQueue(DeleteKind kind, GLsizei n, const GLuint* ids) noexcept
 	{
-		auto filtered = _FilterIds(n, ids);
-		if (filtered.empty())
-			return;
-
-		bool runNow = false;
+		try
 		{
-			std::lock_guard<std::mutex> lock(_Mutex());
-			auto renderThread = _RenderThreadId();
-			runNow = (renderThread != std::thread::id()) && (renderThread == std::this_thread::get_id());
-			if (!runNow)
-			{
-				_Queue().push_back(PendingDelete{ kind, std::move(filtered) });
+			auto filtered = _FilterIds(n, ids);
+			if (filtered.empty())
 				return;
-			}
-		}
 
-		_DeleteNow(kind, filtered);
+			bool runNow = false;
+			{
+				std::lock_guard<std::mutex> lock(_Mutex());
+				auto renderThread = _RenderThreadId();
+				runNow = (renderThread != std::thread::id()) && (renderThread == std::this_thread::get_id());
+				if (!runNow)
+				{
+					_Queue().push_back(PendingDelete{ kind, std::move(filtered) });
+					return;
+				}
+			}
+
+			_DeleteNow(kind, filtered);
+		}
+		catch (...)
+		{
+			// Best-effort: never allow exceptions to escape (often called from destructors).
+		}
 	}
 
 	inline void DeleteBuffers(GLsizei n, const GLuint* ids)

--- a/JammaLib/src/graphics/GlDeleteQueue.h
+++ b/JammaLib/src/graphics/GlDeleteQueue.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <gl/glew.h>
+
+namespace graphics::GlDeleteQueue
+{
+	enum class DeleteKind
+	{
+		Buffers,
+		VertexArrays,
+		Textures,
+		Programs,
+		Framebuffers,
+		Renderbuffers
+	};
+
+	struct PendingDelete
+	{
+		DeleteKind Kind;
+		std::vector<GLuint> Ids;
+	};
+
+	inline std::mutex& _Mutex() noexcept
+	{
+		static std::mutex m;
+		return m;
+	}
+
+	inline std::thread::id& _RenderThreadId() noexcept
+	{
+		static std::thread::id id;
+		return id;
+	}
+
+	inline std::vector<PendingDelete>& _Queue() noexcept
+	{
+		static std::vector<PendingDelete> q;
+		return q;
+	}
+
+	inline void SetRenderThread(std::thread::id id) noexcept
+	{
+		std::lock_guard<std::mutex> lock(_Mutex());
+		_RenderThreadId() = id;
+	}
+
+	inline bool IsRenderThread() noexcept
+	{
+		std::lock_guard<std::mutex> lock(_Mutex());
+		auto renderThread = _RenderThreadId();
+		if (renderThread == std::thread::id())
+			return false;
+
+		return std::this_thread::get_id() == renderThread;
+	}
+
+	inline std::vector<GLuint> _FilterIds(GLsizei n, const GLuint* ids)
+	{
+		std::vector<GLuint> filtered;
+		if ((n <= 0) || (ids == nullptr))
+			return filtered;
+
+		filtered.reserve(static_cast<size_t>(n));
+		for (GLsizei i = 0; i < n; ++i)
+		{
+			if (ids[i] != 0)
+				filtered.push_back(ids[i]);
+		}
+
+		return filtered;
+	}
+
+	inline void _DeleteNow(DeleteKind kind, const std::vector<GLuint>& ids)
+	{
+		if (ids.empty())
+			return;
+
+		switch (kind)
+		{
+		case DeleteKind::Buffers:
+			glDeleteBuffers(static_cast<GLsizei>(ids.size()), ids.data());
+			break;
+		case DeleteKind::VertexArrays:
+			glDeleteVertexArrays(static_cast<GLsizei>(ids.size()), ids.data());
+			break;
+		case DeleteKind::Textures:
+			glDeleteTextures(static_cast<GLsizei>(ids.size()), ids.data());
+			break;
+		case DeleteKind::Programs:
+			for (auto id : ids)
+				glDeleteProgram(id);
+			break;
+		case DeleteKind::Framebuffers:
+			glDeleteFramebuffers(static_cast<GLsizei>(ids.size()), ids.data());
+			break;
+		case DeleteKind::Renderbuffers:
+			glDeleteRenderbuffers(static_cast<GLsizei>(ids.size()), ids.data());
+			break;
+		}
+	}
+
+	inline void _DeleteOrQueue(DeleteKind kind, GLsizei n, const GLuint* ids)
+	{
+		auto filtered = _FilterIds(n, ids);
+		if (filtered.empty())
+			return;
+
+		bool runNow = false;
+		{
+			std::lock_guard<std::mutex> lock(_Mutex());
+			auto renderThread = _RenderThreadId();
+			runNow = (renderThread != std::thread::id()) && (renderThread == std::this_thread::get_id());
+			if (!runNow)
+			{
+				_Queue().push_back(PendingDelete{ kind, std::move(filtered) });
+				return;
+			}
+		}
+
+		_DeleteNow(kind, filtered);
+	}
+
+	inline void DeleteBuffers(GLsizei n, const GLuint* ids)
+	{
+		_DeleteOrQueue(DeleteKind::Buffers, n, ids);
+	}
+
+	inline void DeleteVertexArrays(GLsizei n, const GLuint* ids)
+	{
+		_DeleteOrQueue(DeleteKind::VertexArrays, n, ids);
+	}
+
+	inline void DeleteTextures(GLsizei n, const GLuint* ids)
+	{
+		_DeleteOrQueue(DeleteKind::Textures, n, ids);
+	}
+
+	inline void DeleteProgram(GLuint id)
+	{
+		_DeleteOrQueue(DeleteKind::Programs, 1, &id);
+	}
+
+	inline void DeleteFramebuffers(GLsizei n, const GLuint* ids)
+	{
+		_DeleteOrQueue(DeleteKind::Framebuffers, n, ids);
+	}
+
+	inline void DeleteRenderbuffers(GLsizei n, const GLuint* ids)
+	{
+		_DeleteOrQueue(DeleteKind::Renderbuffers, n, ids);
+	}
+
+	inline void FlushPendingDeletes()
+	{
+		std::vector<PendingDelete> pending;
+		{
+			std::lock_guard<std::mutex> lock(_Mutex());
+			auto renderThread = _RenderThreadId();
+			if ((renderThread == std::thread::id()) || (renderThread != std::this_thread::get_id()))
+				return;
+
+			pending.swap(_Queue());
+		}
+
+		for (auto& item : pending)
+			_DeleteNow(item.Kind, item.Ids);
+	}
+}

--- a/JammaLib/src/graphics/GlDrawContext.cpp
+++ b/JammaLib/src/graphics/GlDrawContext.cpp
@@ -1,4 +1,5 @@
 #include "GlDrawContext.h"
+#include "GlDeleteQueue.h"
 
 using namespace graphics;
 using namespace utils;
@@ -15,13 +16,13 @@ GlDrawContext::~GlDrawContext()
 {
 	if (_texture)
 	{
-		glDeleteTextures(1, &_texture);
+		GlDeleteQueue::DeleteTextures(1, &_texture);
 		_texture = 0u;
 	}
 
 	if (SCREEN != _target)
 	{
-		glDeleteFramebuffers(1, &_frameBuffer);
+		GlDeleteQueue::DeleteFramebuffers(1, &_frameBuffer);
 		_frameBuffer = 0u;
 	}
 }
@@ -30,13 +31,13 @@ void GlDrawContext::Initialise()
 {
 	if (_texture)
 	{
-		glDeleteTextures(1, &_texture);
+		GlDeleteQueue::DeleteTextures(1, &_texture);
 		_texture = 0u;
 	}
 
 	if (_frameBuffer)
 	{
-		glDeleteFramebuffers(1, &_frameBuffer);
+		GlDeleteQueue::DeleteFramebuffers(1, &_frameBuffer);
 		_frameBuffer = 0u;
 	}
 

--- a/JammaLib/src/graphics/Image.cpp
+++ b/JammaLib/src/graphics/Image.cpp
@@ -1,4 +1,5 @@
 ﻿#include "Image.h"
+#include "GlDeleteQueue.h"
 #include <gl/glew.h>
 #include <gl/gl.h>
 #include "gl/glext.h"
@@ -78,11 +79,11 @@ void Image::_InitResources(ResourceLib& resourceLib, bool forceInit)
 
 void Image::_ReleaseResources()
 {
-	glDeleteBuffers(2, _vertexBuffer);
+	GlDeleteQueue::DeleteBuffers(2, _vertexBuffer);
 	_vertexBuffer[0] = 0;
 	_vertexBuffer[1] = 0;
 
-	glDeleteVertexArrays(1, &_vertexArray);
+	GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
 	_vertexArray = 0;
 
 	_isDrawInitialised = false;

--- a/JammaLib/src/graphics/ImageFullscreen.cpp
+++ b/JammaLib/src/graphics/ImageFullscreen.cpp
@@ -1,4 +1,5 @@
 ﻿#include "ImageFullscreen.h"
+#include "GlDeleteQueue.h"
 #include <gl/glew.h>
 #include <gl/gl.h>
 #include "gl/glext.h"
@@ -68,7 +69,7 @@ void ImageFullscreen::_InitResources(ResourceLib& resourceLib, bool forceInit)
 
 void ImageFullscreen::_ReleaseResources()
 {
-	glDeleteVertexArrays(1, &_vertexArray);
+	GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
 	_vertexArray = 0;
 }
 

--- a/JammaLib/src/graphics/LoopModel.cpp
+++ b/JammaLib/src/graphics/LoopModel.cpp
@@ -1,4 +1,5 @@
 #include "LoopModel.h"
+#include "GlDeleteQueue.h"
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -238,11 +239,11 @@ void LoopModel::_ReleaseResources()
 {
 	if (0u != _waveformTexture)
 	{
-		glDeleteTextures(1, &_waveformTexture);
+		graphics::GlDeleteQueue::DeleteTextures(1, &_waveformTexture);
 		_waveformTexture = 0u;
 	}
 
-	glDeleteBuffers(_WaveformPboCount, _waveformPbos.data());
+	graphics::GlDeleteQueue::DeleteBuffers(_WaveformPboCount, _waveformPbos.data());
 	_waveformPbos.fill(0u);
 
 	GuiModel::_ReleaseResources();

--- a/JammaLib/src/graphics/NinePatchImage.cpp
+++ b/JammaLib/src/graphics/NinePatchImage.cpp
@@ -1,4 +1,5 @@
 ﻿#include "NinePatchImage.h"
+#include "GlDeleteQueue.h"
 #include <algorithm>
 #include <iostream>
 #include <gl/glew.h>
@@ -160,11 +161,11 @@ void NinePatchImage::_InitResources(ResourceLib& resourceLib, bool forceInit)
 
 void NinePatchImage::_ReleaseResources()
 {
-	glDeleteBuffers(2, _vertexBuffer);
+	GlDeleteQueue::DeleteBuffers(2, _vertexBuffer);
 	_vertexBuffer[0] = 0;
 	_vertexBuffer[1] = 0;
 
-	glDeleteVertexArrays(1, &_vertexArray);
+	GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
 	_vertexArray = 0;
 
 	_isDrawInitialised = false;

--- a/JammaLib/src/graphics/Skybox.cpp
+++ b/JammaLib/src/graphics/Skybox.cpp
@@ -1,4 +1,5 @@
 #include "Skybox.h"
+#include "GlDeleteQueue.h"
 #include <gl/glew.h>
 #include <gl/gl.h>
 
@@ -103,12 +104,12 @@ void Skybox::ReleaseResources()
 {
 	if (_vao)
 	{
-		glDeleteVertexArrays(1, &_vao);
+		GlDeleteQueue::DeleteVertexArrays(1, &_vao);
 		_vao = 0;
 	}
 	if (_vbo)
 	{
-		glDeleteBuffers(1, &_vbo);
+		GlDeleteQueue::DeleteBuffers(1, &_vbo);
 		_vbo = 0;
 	}
 	_initialised = false;

--- a/JammaLib/src/graphics/Window.cpp
+++ b/JammaLib/src/graphics/Window.cpp
@@ -7,6 +7,8 @@
 
 #include "Window.h"
 #include "StringUtils.h"
+#include "GlDeleteQueue.h"
+#include <thread>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb/stb_image_write.h"
 
@@ -51,6 +53,8 @@ Window::~Window()
 
 void Window::ReleaseGlResources()
 {
+	GlDeleteQueue::FlushPendingDeletes();
+
 	_scene.ReleaseResources();
 	_highlightPass.ReleaseResources();
 
@@ -59,6 +63,8 @@ void Window::ReleaseGlResources()
 	_textureContext.reset();
 
 	_resourceLib.ClearResources();
+
+	GlDeleteQueue::FlushPendingDeletes();
 }
 
 void Window::LoadResources()
@@ -272,6 +278,7 @@ int Window::Create(HINSTANCE hInstance, int nCmdShow)
 	}
 
 	wglSwapIntervalEXT(1);
+	GlDeleteQueue::SetRenderThread(std::this_thread::get_id());
 
 	// Init opengl loader here (extra safe version)
 	GLenum err = glewInit();
@@ -376,6 +383,8 @@ Size2d Window::GetSize()
 
 void Window::Render()
 {
+	GlDeleteQueue::FlushPendingDeletes();
+
 	_scene.CommitChanges();
 	_scene.InitResources(_resourceLib, false);
 

--- a/JammaLib/src/gui/GuiLabel.cpp
+++ b/JammaLib/src/gui/GuiLabel.cpp
@@ -1,4 +1,5 @@
 #include "GuiLabel.h"
+#include "../graphics/GlDeleteQueue.h"
 #include "glm/glm.hpp"
 #include "glm/ext.hpp"
 
@@ -10,6 +11,8 @@ using namespace resources;
 GuiLabel::GuiLabel(GuiLabelParams guiParams) :
 	GuiElement(guiParams),
 	_str(guiParams.String),
+	_pendingStr(guiParams.String),
+	_vertexArrayDirty(true),
 	_vertexArray(0),
 	_texture(std::weak_ptr<TextureResource>()),
 	_shader(std::weak_ptr<ShaderResource>()),
@@ -19,19 +22,12 @@ GuiLabel::GuiLabel(GuiLabelParams guiParams) :
 
 void GuiLabel::SetString(const std::string& str)
 {
-	if (_str == str)
+	std::lock_guard<std::mutex> lock(_stringMutex);
+	if (_pendingStr == str)
 		return;
 
-	_str = str;
-
-	auto font = _font.lock();
-	if (!font)
-		return;
-
-	if (_vertexArray != 0)
-		glDeleteVertexArrays(1, &_vertexArray);
-
-	_vertexArray = font->InitVertexArray(_str, GL_STATIC_DRAW);
+	_pendingStr = str;
+	_vertexArrayDirty.store(true, std::memory_order_release);
 }
 
 void GuiLabel::Draw(DrawContext& ctx)
@@ -39,6 +35,10 @@ void GuiLabel::Draw(DrawContext& ctx)
 	auto font = _font.lock();
 
 	if (!font)
+		return;
+
+	SyncVertexArray();
+	if (_vertexArray == 0)
 		return;
 
 	auto glCtx = dynamic_cast<GlDrawContext&>(ctx);
@@ -61,6 +61,7 @@ void GuiLabel::_InitResources(ResourceLib& resourceLib, bool forceInit)
 		return;
 
 	_font = fontOpt.value();
+	_vertexArrayDirty.store(true, std::memory_order_release);
 
 	auto validated = InitVertexArray();
 
@@ -69,7 +70,8 @@ void GuiLabel::_InitResources(ResourceLib& resourceLib, bool forceInit)
 
 void GuiLabel::_ReleaseResources()
 {
-	glDeleteVertexArrays(1, &_vertexArray);
+	graphics::GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
+	_vertexArray = 0;
 }
 
 bool GuiLabel::InitVertexArray()
@@ -79,6 +81,26 @@ bool GuiLabel::InitVertexArray()
 	if (!font)
 		return false;
 		
-	_vertexArray = font->InitVertexArray(_str, GL_STATIC_DRAW);
+	SyncVertexArray();
 	return true;
+}
+
+void GuiLabel::SyncVertexArray()
+{
+	if (!_vertexArrayDirty.exchange(false, std::memory_order_acq_rel))
+		return;
+
+	std::string next;
+	{
+		std::lock_guard<std::mutex> lock(_stringMutex);
+		next = _pendingStr;
+	}
+
+	auto font = _font.lock();
+	if (!font)
+		return;
+
+	graphics::GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
+	_vertexArray = font->InitVertexArray(next, GL_STATIC_DRAW);
+	_str = next;
 }

--- a/JammaLib/src/gui/GuiLabel.cpp
+++ b/JammaLib/src/gui/GuiLabel.cpp
@@ -14,6 +14,7 @@ GuiLabel::GuiLabel(GuiLabelParams guiParams) :
 	_pendingStr(guiParams.String),
 	_vertexArrayDirty(true),
 	_vertexArray(0),
+	_vertexBuffers{ 0, 0 },
 	_texture(std::weak_ptr<TextureResource>()),
 	_shader(std::weak_ptr<ShaderResource>()),
 	_font(std::weak_ptr<Font>())
@@ -51,6 +52,7 @@ void GuiLabel::Draw(DrawContext& ctx)
 	glCtx.PushMvp(glm::scale(glm::translate(glm::mat4(1.0), glm::vec3(pos.X, pos.Y, 0.f)), glm::vec3(scale, scale, 1.0f)));
 	
 	font->Draw(glCtx, _vertexArray, (unsigned int)_str.size());
+	glCtx.PopMvp();
 }
 
 void GuiLabel::_InitResources(ResourceLib& resourceLib, bool forceInit)
@@ -70,6 +72,9 @@ void GuiLabel::_InitResources(ResourceLib& resourceLib, bool forceInit)
 
 void GuiLabel::_ReleaseResources()
 {
+	graphics::GlDeleteQueue::DeleteBuffers(2, _vertexBuffers);
+	_vertexBuffers[0] = 0;
+	_vertexBuffers[1] = 0;
 	graphics::GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
 	_vertexArray = 0;
 }
@@ -100,7 +105,10 @@ void GuiLabel::SyncVertexArray()
 	if (!font)
 		return;
 
+	graphics::GlDeleteQueue::DeleteBuffers(2, _vertexBuffers);
+	_vertexBuffers[0] = 0;
+	_vertexBuffers[1] = 0;
 	graphics::GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
-	_vertexArray = font->InitVertexArray(next, GL_STATIC_DRAW);
+	_vertexArray = font->InitVertexArray(next, GL_STATIC_DRAW, &_vertexBuffers[0], &_vertexBuffers[1]);
 	_str = next;
 }

--- a/JammaLib/src/gui/GuiLabel.h
+++ b/JammaLib/src/gui/GuiLabel.h
@@ -51,6 +51,7 @@ namespace gui
 		std::mutex _stringMutex;
 		std::atomic<bool> _vertexArrayDirty;
 		GLuint _vertexArray;
+		GLuint _vertexBuffers[2];
 		std::weak_ptr<resources::TextureResource> _texture;
 		std::weak_ptr<resources::ShaderResource> _shader;
 		std::weak_ptr<graphics::Font> _font;

--- a/JammaLib/src/gui/GuiLabel.h
+++ b/JammaLib/src/gui/GuiLabel.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <atomic>
+#include <mutex>
 #include "GuiElement.h"
 #include "Drawable.h"
 #include "../graphics/Font.h"
@@ -40,10 +42,14 @@ namespace gui
 		virtual void _ReleaseResources() override;
 
 	private:
+		void SyncVertexArray();
 		bool InitVertexArray();
 
 	private:
 		std::string _str;
+		std::string _pendingStr;
+		std::mutex _stringMutex;
+		std::atomic<bool> _vertexArrayDirty;
 		GLuint _vertexArray;
 		std::weak_ptr<resources::TextureResource> _texture;
 		std::weak_ptr<resources::ShaderResource> _shader;

--- a/JammaLib/src/gui/GuiModel.cpp
+++ b/JammaLib/src/gui/GuiModel.cpp
@@ -1,4 +1,5 @@
 #include "GuiModel.h"
+#include "../graphics/GlDeleteQueue.h"
 #include "glm/glm.hpp"
 #include "glm/ext.hpp"
 
@@ -140,18 +141,18 @@ void GuiModel::_InitResources(ResourceLib& resourceLib, bool forceInit)
 
 void GuiModel::_ReleaseResources()
 {
-	glDeleteBuffers(3, _vertexBuffer);
+	graphics::GlDeleteQueue::DeleteBuffers(3, _vertexBuffer);
 	_vertexBuffer[0] = 0;
 	_vertexBuffer[1] = 0;
 	_vertexBuffer[2] = 0;
 
 	if (!_instanceBuffers.empty())
 	{
-		glDeleteBuffers((GLsizei)_instanceBuffers.size(), _instanceBuffers.data());
+		graphics::GlDeleteQueue::DeleteBuffers((GLsizei)_instanceBuffers.size(), _instanceBuffers.data());
 		_instanceBuffers.clear();
 	}
 
-	glDeleteVertexArrays(1, &_vertexArray);
+	graphics::GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
 	_vertexArray = 0;
 }
 
@@ -347,7 +348,7 @@ bool GuiModel::SyncInstanceAttributes()
 	{
 		if (!_instanceBuffers.empty())
 		{
-			glDeleteBuffers((GLsizei)_instanceBuffers.size(), _instanceBuffers.data());
+			graphics::GlDeleteQueue::DeleteBuffers((GLsizei)_instanceBuffers.size(), _instanceBuffers.data());
 			_instanceBuffers.clear();
 		}
 
@@ -360,7 +361,7 @@ bool GuiModel::SyncInstanceAttributes()
 	{
 		if (!_instanceBuffers.empty())
 		{
-			glDeleteBuffers((GLsizei)_instanceBuffers.size(), _instanceBuffers.data());
+			graphics::GlDeleteQueue::DeleteBuffers((GLsizei)_instanceBuffers.size(), _instanceBuffers.data());
 			_instanceBuffers.clear();
 		}
 

--- a/JammaLib/src/gui/GuiRouter.cpp
+++ b/JammaLib/src/gui/GuiRouter.cpp
@@ -1,4 +1,5 @@
 #include "GuiRouter.h"
+#include "../graphics/GlDeleteQueue.h"
 
 using namespace base;
 using namespace gui;
@@ -450,10 +451,10 @@ void GuiRouter::_InitResources(ResourceLib& resourceLib, bool forceInit)
 
 void GuiRouter::_ReleaseResources()
 {
-	glDeleteBuffers(1, &_vertexBuffer);
+	graphics::GlDeleteQueue::DeleteBuffers(1, &_vertexBuffer);
 	_vertexBuffer = 0;
 
-	glDeleteVertexArrays(1, &_vertexArray);
+	graphics::GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
 	_vertexArray = 0;
 }
 

--- a/JammaLib/src/gui/GuiVu.cpp
+++ b/JammaLib/src/gui/GuiVu.cpp
@@ -1,4 +1,5 @@
 #include "GuiVu.h"
+#include "../graphics/GlDeleteQueue.h"
 #include "glm/glm.hpp"
 #include "glm/ext.hpp"
 
@@ -197,14 +198,14 @@ void GuiVu::_ReleaseResources()
 {
 	if (_vertexBuffer[0] || _vertexBuffer[1])
 	{
-		glDeleteBuffers(2, _vertexBuffer);
+		graphics::GlDeleteQueue::DeleteBuffers(2, _vertexBuffer);
 		_vertexBuffer[0] = 0;
 		_vertexBuffer[1] = 0;
 	}
 
 	if (_vertexArray)
 	{
-		glDeleteVertexArrays(1, &_vertexArray);
+		graphics::GlDeleteQueue::DeleteVertexArrays(1, &_vertexArray);
 		_vertexArray = 0;
 	}
 }

--- a/JammaLib/src/midi/MidiIndexedOutputSink.cpp
+++ b/JammaLib/src/midi/MidiIndexedOutputSink.cpp
@@ -1,0 +1,22 @@
+#include "MidiIndexedOutputSink.h"
+
+namespace midi
+{
+	MidiIndexedOutputSink::MidiIndexedOutputSink(IMidiOutputSink& outputSink,
+		unsigned int outputIndex,
+		std::uint32_t midiBlockStart,
+		std::uint32_t outputBlockStart) noexcept :
+		_outputSink(outputSink),
+		_outputIndex(outputIndex),
+		_midiBlockStart(midiBlockStart),
+		_outputBlockStart(outputBlockStart)
+	{
+	}
+
+	void MidiIndexedOutputSink::OnEvent(const MidiEvent& ev) noexcept
+	{
+		MidiEvent mapped = ev;
+		mapped.sampleOffset = _outputBlockStart + (ev.sampleOffset - _midiBlockStart);
+		_outputSink.OnEvent(_outputIndex, mapped);
+	}
+}

--- a/JammaLib/src/midi/MidiIndexedOutputSink.h
+++ b/JammaLib/src/midi/MidiIndexedOutputSink.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+#include "MidiLoop.h"
+
+namespace midi
+{
+	class MidiIndexedOutputSink final : public IMidiSink
+	{
+	public:
+		MidiIndexedOutputSink(IMidiOutputSink& outputSink,
+			unsigned int outputIndex,
+			std::uint32_t midiBlockStart,
+			std::uint32_t outputBlockStart) noexcept;
+
+		void OnEvent(const MidiEvent& ev) noexcept override;
+
+	private:
+		IMidiOutputSink& _outputSink;
+		unsigned int _outputIndex;
+		std::uint32_t _midiBlockStart;
+		std::uint32_t _outputBlockStart;
+	};
+}

--- a/JammaLib/src/midi/MidiVstOutputSink.cpp
+++ b/JammaLib/src/midi/MidiVstOutputSink.cpp
@@ -1,0 +1,43 @@
+#include "MidiVstOutputSink.h"
+
+#include "../vst/VstChain.h"
+
+namespace midi
+{
+	MidiVstOutputSink::MidiVstOutputSink(vst::VstChain* chain,
+		const MidiVstRoutingSnapshot* routes) noexcept :
+		_chain(chain),
+		_routes(routes)
+	{
+	}
+
+	void MidiVstOutputSink::OnEvent(unsigned int outputIndex, const MidiEvent& event) noexcept
+	{
+		SendMidiToVstChain(_chain, _routes, event, false, outputIndex);
+	}
+
+	void SendMidiToVstChain(vst::VstChain* chain,
+		const MidiVstRoutingSnapshot* routes,
+		const MidiEvent& event,
+		bool isRealtime,
+		unsigned int midiOutputIndex) noexcept
+	{
+		if (!chain)
+			return;
+
+		if (!routes || !routes->HasRoutes())
+		{
+			chain->SendMidiEvent(event, isRealtime);
+			return;
+		}
+
+		const auto pluginIndex = routes->PluginForOutput(midiOutputIndex);
+		if (pluginIndex != MidiVstRoutingSnapshot::NoPlugin && pluginIndex < chain->NumPlugins())
+		{
+			chain->SendMidiEventToPlugin(pluginIndex, event, isRealtime);
+			return;
+		}
+
+		chain->SendMidiEvent(event, isRealtime);
+	}
+}

--- a/JammaLib/src/midi/MidiVstOutputSink.h
+++ b/JammaLib/src/midi/MidiVstOutputSink.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "MidiLoop.h"
+
+namespace vst
+{
+	class VstChain;
+}
+
+namespace midi
+{
+	static constexpr unsigned int LiveMidiOutputIndex = ~0u;
+
+	struct MidiVstRoutingSnapshot
+	{
+		static constexpr size_t NoPlugin = (std::numeric_limits<size_t>::max)();
+
+		std::vector<size_t> PluginByMidiOutput;
+		size_t LivePlugin = NoPlugin;
+
+		bool HasRoutes() const noexcept
+		{
+			if (LivePlugin != NoPlugin)
+				return true;
+			for (const auto pluginIndex : PluginByMidiOutput)
+			{
+				if (pluginIndex != NoPlugin)
+					return true;
+			}
+			return false;
+		}
+
+		size_t PluginForOutput(unsigned int midiOutputIndex) const noexcept
+		{
+			if (midiOutputIndex == LiveMidiOutputIndex)
+				return LivePlugin;
+			if (midiOutputIndex < PluginByMidiOutput.size())
+				return PluginByMidiOutput[midiOutputIndex];
+			return NoPlugin;
+		}
+	};
+
+	void SendMidiToVstChain(vst::VstChain* chain,
+		const MidiVstRoutingSnapshot* routes,
+		const MidiEvent& event,
+		bool isRealtime,
+		unsigned int midiOutputIndex) noexcept;
+
+	class MidiVstOutputSink final : public IMidiOutputSink
+	{
+	public:
+		MidiVstOutputSink(vst::VstChain* chain,
+			const MidiVstRoutingSnapshot* routes) noexcept;
+
+		void OnEvent(unsigned int outputIndex, const MidiEvent& event) noexcept override;
+
+	private:
+		vst::VstChain* _chain;
+		const MidiVstRoutingSnapshot* _routes;
+	};
+}

--- a/JammaLib/src/resources/CubemapResource.cpp
+++ b/JammaLib/src/resources/CubemapResource.cpp
@@ -1,4 +1,5 @@
 #include "CubemapResource.h"
+#include "../graphics/GlDeleteQueue.h"
 
 using namespace resources;
 
@@ -15,7 +16,7 @@ CubemapResource::~CubemapResource()
 
 void CubemapResource::Release()
 {
-	glDeleteTextures(1, &_texture);
+	graphics::GlDeleteQueue::DeleteTextures(1, &_texture);
 	_texture = 0;
 }
 
@@ -38,7 +39,7 @@ std::optional<GLuint> CubemapResource::Load(const std::string& baseName)
 		if (!imageLoaded.has_value())
 		{
 			glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
-			glDeleteTextures(1, &texture);
+			graphics::GlDeleteQueue::DeleteTextures(1, &texture);
 			return std::nullopt;
 		}
 

--- a/JammaLib/src/resources/ShaderResource.cpp
+++ b/JammaLib/src/resources/ShaderResource.cpp
@@ -1,4 +1,5 @@
 #include "ShaderResource.h"
+#include "../graphics/GlDeleteQueue.h"
 #include "glm/gtc/type_ptr.hpp"
 
 using namespace resources;
@@ -30,7 +31,7 @@ std::optional<GLuint> ShaderResource::Load(const std::string& vertFilePath, cons
 
 	if (!res)
 	{
-		glDeleteProgram(shaderProgram);
+		graphics::GlDeleteQueue::DeleteProgram(shaderProgram);
 		return std::nullopt;
 	}
 
@@ -41,7 +42,7 @@ std::optional<GLuint> ShaderResource::Load(const std::string& vertFilePath, cons
 
 	if (GL_FALSE == glResult)
 	{
-		glDeleteProgram(shaderProgram);
+		graphics::GlDeleteQueue::DeleteProgram(shaderProgram);
 		return std::nullopt;
 	}
 
@@ -50,7 +51,7 @@ std::optional<GLuint> ShaderResource::Load(const std::string& vertFilePath, cons
 
 void ShaderResource::Release()
 {
-	glDeleteProgram(_shaderProgram);
+	graphics::GlDeleteQueue::DeleteProgram(_shaderProgram);
 	_shaderProgram = 0;
 }
 

--- a/JammaLib/src/resources/TextureResource.cpp
+++ b/JammaLib/src/resources/TextureResource.cpp
@@ -1,4 +1,5 @@
 #include "TextureResource.h"
+#include "../graphics/GlDeleteQueue.h"
 
 using namespace resources;
 
@@ -20,7 +21,7 @@ TextureResource::~TextureResource()
 
 void TextureResource::Release()
 {
-	glDeleteTextures(1, &_texture);
+	graphics::GlDeleteQueue::DeleteTextures(1, &_texture);
 	_texture = 0;
 }
 


### PR DESCRIPTION
This pull request introduces a thread-safe mechanism for OpenGL resource deletion by replacing direct OpenGL delete calls with a new `GlDeleteQueue` utility. The change ensures that OpenGL resources (buffers, textures, framebuffers, etc.) are deleted on the correct render thread, preventing potential threading issues and crashes. Additionally, the design of several audio engine data structures is updated to use `weak_ptr` for holding references, improving memory safety and preventing unintended destructor calls on the wrong thread.

The most important changes are:

**OpenGL Resource Deletion and Thread Safety:**

* Added the new `GlDeleteQueue` utility (`JammaLib/src/graphics/GlDeleteQueue.h`) to queue and safely delete OpenGL resources on the correct thread. This includes logic for tracking the render thread, filtering resource IDs, and flushing pending deletions.
* Updated all graphics/resource classes (such as `GlDrawContext`, `Image`, `ImageFullscreen`, `LoopModel`, `NinePatchImage`, `Skybox`, and `Window`) to use `GlDeleteQueue` methods instead of direct OpenGL delete calls, ensuring thread-safe resource management. [[1]](diffhunk://#diff-5a864b6b2be027fe3a563bdb28858339d8aec5eee863b6f34ebddee6881747ccR2) [[2]](diffhunk://#diff-5a864b6b2be027fe3a563bdb28858339d8aec5eee863b6f34ebddee6881747ccL18-R25) [[3]](diffhunk://#diff-5a864b6b2be027fe3a563bdb28858339d8aec5eee863b6f34ebddee6881747ccL33-R40) [[4]](diffhunk://#diff-55fd2da11440c5d463b9731d91e3f4a14e1b5a403e8ac9933ce34893ef715181R2) [[5]](diffhunk://#diff-55fd2da11440c5d463b9731d91e3f4a14e1b5a403e8ac9933ce34893ef715181L81-R86) [[6]](diffhunk://#diff-3c6bfb538a7498d948143695eafecbc3e1aba626d4b154b7c29d5e5bbf7a76f1R2) [[7]](diffhunk://#diff-3c6bfb538a7498d948143695eafecbc3e1aba626d4b154b7c29d5e5bbf7a76f1L71-R72) [[8]](diffhunk://#diff-265814a7b88d54ad84b7e14ee8c4de55b4d4e24c9a9699fb0035f2bc45f1a995R2) [[9]](diffhunk://#diff-265814a7b88d54ad84b7e14ee8c4de55b4d4e24c9a9699fb0035f2bc45f1a995L241-R246) [[10]](diffhunk://#diff-a960e3dcf7159f4790cb281475bff6297fc5833bd47924b9b22ce392f85033afR2) [[11]](diffhunk://#diff-a960e3dcf7159f4790cb281475bff6297fc5833bd47924b9b22ce392f85033afL163-R168) [[12]](diffhunk://#diff-c29ea9291d0a375250abe0a1ccb8f966a41714b12138660044c1f558d63b39c7R2) [[13]](diffhunk://#diff-c29ea9291d0a375250abe0a1ccb8f966a41714b12138660044c1f558d63b39c7L106-R112) [[14]](diffhunk://#diff-6e0354039bb9e0bd5d4dd721a77587b41c57f41eba18c10a56d2419371607feeR10-R11)

**Audio Engine Memory Safety:**

* Changed `AudioState` structures in `LoopTake` and `Station` to store `weak_ptr` to loops/takes instead of `shared_ptr`, preventing destructor calls (which may trigger OpenGL resource deletion) on non-render threads. [[1]](diffhunk://#diff-cb5a800b377fe63dc8d839e7d8d23b99a544a5c77d085dfd1c281b19d01bffe6L220-R221) [[2]](diffhunk://#diff-72738db198029ce6222b15803fb52f7c08fa0abb10e54e7b0fa9a6fcaffdff1bL203-R204)
* Updated all related code in `LoopTake.cpp` and `Station.cpp` to lock `weak_ptr` before use, ensuring resources are only accessed if still valid. [[1]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39L355-R356) [[2]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39L379-R381) [[3]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39L449-R448) [[4]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39L485-R484) [[5]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39L1839-R1837) [[6]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL312-R313) [[7]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL351-R353) [[8]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL402-R401) [[9]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL431-R431) [[10]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL461-R461) [[11]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL476-R476) [[12]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL1184-R1193)
* Modified snapshot and publish methods to properly copy or reserve space for `weak_ptr` containers. [[1]](diffhunk://#diff-0829d999c8f06185fa4cbbc891d21d5b1d970a7866ae036b9ee20ded4b304f39L1865-R1865) [[2]](diffhunk://#diff-8677647499852564bc63e91219ac9f4c86abeccee46000970e4074e1afac1a4bL1463-R1467)

These changes collectively improve the stability and safety of both graphics and audio subsystems, especially in multithreaded scenarios.