### PR TITLE
Bugfix/hover station

### DIFF
--- a/JammaLib/src/engine/Scene.cpp
+++ b/JammaLib/src/engine/Scene.cpp
@@ -1232,8 +1232,9 @@ void Scene::CommitChanges()
 		_InvalidateHover2d();
 }
 
-void Scene::ResolveDeferredHover()
+void Scene::ApplyDeferredHoverUpdates()
 {
+	// Keep active hover in sync with both deferred 2D hit-testing and latest 3D picker result.
 	if (!_hover2dDirty)
 		return;
 
@@ -1255,6 +1256,8 @@ void Scene::ResolveDeferredHover()
 
 	auto nextPath = _ResolveHoverPath2d();
 	_ApplyHoverPath2d(nextPath);
+
+	bool stationHoverPromotedFrom2d = false;
 
 	if (!nextPath.empty())
 	{
@@ -1287,7 +1290,17 @@ void Scene::ResolveDeferredHover()
 				isSelected,
 				tweakState);
 			_UpdateSelection(ACTIONRESULT_DEFAULT);
+			stationHoverPromotedFrom2d = true;
 		}
+	}
+
+	if (!stationHoverPromotedFrom2d && _hoverPath3d.empty() && !_selector->CurrentHover().empty())
+	{
+		_selector->UpdateCurrentHover({ },
+			Action::MODIFIER_NONE,
+			false,
+			base::Tweakable::TweakState::TWEAKSTATE_NONE);
+		_UpdateSelection(ACTIONRESULT_DEFAULT);
 	}
 
 	_hoverPath2d = std::move(nextPath);

--- a/JammaLib/src/engine/Scene.cpp
+++ b/JammaLib/src/engine/Scene.cpp
@@ -1036,21 +1036,21 @@ void Scene::SetHover3d(std::vector<unsigned char> path, Action::Modifiers modifi
 
 	elementPath = TrimPath(elementPath, _selector->CurrentSelectDepth() + 1);
 
-	if ((elementPath != _lastLoggedHoverPath) && (_loggingConfig.Ui == "verbose"))
+	if (elementPath != _lastLoggedHoverPath)
 	{
-		std::string pathString = "[";
-		for (size_t i = 0; i < elementPath.size(); ++i)
+		if (_loggingConfig.Ui == "verbose")
 		{
-			pathString += std::to_string(static_cast<unsigned int>(elementPath[i]));
-			if ((i + 1) < elementPath.size())
-				pathString += ",";
+			std::string pathString = "[";
+			for (size_t i = 0; i < elementPath.size(); ++i)
+			{
+				pathString += std::to_string(static_cast<unsigned int>(elementPath[i]));
+				if ((i + 1) < elementPath.size())
+					pathString += ",";
+			}
+			pathString += "]";
+			std::cout << "Hover3d resolved: " << pathString << std::endl;
 		}
-		pathString += "]";
-		std::cout << "Hover3d resolved: " << pathString << std::endl;
-		_lastLoggedHoverPath = elementPath;
-	}
-	else if (elementPath != _lastLoggedHoverPath)
-	{
+
 		_lastLoggedHoverPath = elementPath;
 	}
 
@@ -1110,6 +1110,8 @@ void Scene::InitAudio()
 void Scene::SetLogging(io::LoggingConfig config) noexcept
 {
 	_loggingConfig = config;
+	if (_windowSubsystem)
+		_windowSubsystem->SetLogging(_loggingConfig);
 	for (auto& station : _stations)
 	{
 		if (station)
@@ -1253,6 +1255,41 @@ void Scene::ResolveDeferredHover()
 
 	auto nextPath = _ResolveHoverPath2d();
 	_ApplyHoverPath2d(nextPath);
+
+	if (!nextPath.empty())
+	{
+		auto nextShared = _LockHoverPath(nextPath);
+		auto stationIt = std::find_if(nextShared.begin(), nextShared.end(), [](const std::shared_ptr<base::GuiElement>& element) {
+			return nullptr != std::dynamic_pointer_cast<Station>(element);
+		});
+
+		if (stationIt != nextShared.end())
+		{
+			auto stationGlobalId = (*stationIt)->GlobalId();
+			std::vector<unsigned char> stationPathRaw;
+			stationPathRaw.reserve(stationGlobalId.size());
+			for (auto part : stationGlobalId)
+				stationPathRaw.push_back(static_cast<unsigned char>(part & 0xFFu));
+
+			auto stationPath = TrimPath(stationPathRaw, _selector->CurrentSelectDepth() + 1u);
+			bool isSelected = false;
+			auto tweakState = base::Tweakable::TweakState::TWEAKSTATE_NONE;
+			auto hovering = _ChildFromPath(stationPath);
+			if (hovering)
+			{
+				isSelected = hovering->IsSelected();
+				if (auto tweakable = std::dynamic_pointer_cast<Tweakable>(hovering))
+					tweakState = tweakable->GetTweakState();
+			}
+
+			_selector->UpdateCurrentHover(stationPath,
+				Action::MODIFIER_NONE,
+				isSelected,
+				tweakState);
+			_UpdateSelection(ACTIONRESULT_DEFAULT);
+		}
+	}
+
 	_hoverPath2d = std::move(nextPath);
 	_hover2dDirty = false;
 }

--- a/JammaLib/src/engine/Scene.cpp
+++ b/JammaLib/src/engine/Scene.cpp
@@ -1024,7 +1024,8 @@ void Scene::SetHover3d(std::vector<unsigned char> path, Action::Modifiers modifi
 
 	for (auto segment : path)
 	{
-		if (0 == segment)
+		// Picker path uses 0xFF as the terminator for missing path segments.
+		if ((0xFF == segment) || (0 == segment))
 			break;
 
 		fullElementPath.push_back(segment - 1);

--- a/JammaLib/src/engine/Scene.h
+++ b/JammaLib/src/engine/Scene.h
@@ -219,7 +219,7 @@ namespace engine
 		void InitSerial() {}
 		void CloseSerial() {}
 		void CommitChanges();
-		void ResolveDeferredHover();
+		void ApplyDeferredHoverUpdates();
 
 		// Returns a locked snapshot of the current station list.  Always use
 		// this when reading _stations from outside the render/tick thread (e.g.

--- a/JammaLib/src/graphics/StationModel.cpp
+++ b/JammaLib/src/graphics/StationModel.cpp
@@ -450,10 +450,15 @@ void StationModel::Draw3d(DrawContext& ctx,
 	case base::PASS_PICKER:
 	{
 		auto idVec = _stationGlobalId.empty() ? GlobalId() : _stationGlobalId;
+		const auto usedSize = idVec.size();
 		idVec.resize(3);
-		for (auto& idPart : idVec)
-			idPart += 1;
+		for (size_t i = 0; i < usedSize; ++i)
+			idVec[i] += 1;
 		const auto id = utils::VecToId(idVec);
+		// Shared picker vertex shader expects loop waveform scale uniforms.
+		// Keep station picker geometry unscaled by pinning to 1:1.
+		glCtx.SetUniform("WaveformRadius", 1.0f);
+		glCtx.SetUniform("WaveformUnitMeshRadius", 1.0f);
 		glCtx.SetUniform("ObjectId", id);
 		break;
 	}

--- a/JammaLib/src/graphics/StationModel.cpp
+++ b/JammaLib/src/graphics/StationModel.cpp
@@ -450,7 +450,7 @@ void StationModel::Draw3d(DrawContext& ctx,
 	case base::PASS_PICKER:
 	{
 		auto idVec = _stationGlobalId.empty() ? GlobalId() : _stationGlobalId;
-		const auto usedSize = idVec.size();
+		const auto usedSize = std::min(idVec.size(), static_cast<size_t>(3));
 		idVec.resize(3);
 		for (size_t i = 0; i < usedSize; ++i)
 			idVec[i] += 1;

--- a/JammaLib/src/graphics/Window.cpp
+++ b/JammaLib/src/graphics/Window.cpp
@@ -480,7 +480,7 @@ void Window::Render()
 		_hover3dDirty = false;
 	}
 
-	_scene.ResolveDeferredHover();
+	_scene.ApplyDeferredHoverUpdates();
 
 	// Save the picker render to bmp:
 	// std::vector<unsigned char> data = _pickContext->GetTexture();

--- a/JammaLib/src/vst/VstEditorWindowManager.cpp
+++ b/JammaLib/src/vst/VstEditorWindowManager.cpp
@@ -239,35 +239,34 @@ namespace vst
 	{
 		if (!hovering)
 			return false;
+		(void)depth;
 
-		switch (depth)
+		for (auto current = hovering; current; current = current->Parent())
 		{
-		case base::SelectDepth::DEPTH_STATION:
-		{
-			auto station = std::dynamic_pointer_cast<Station>(hovering);
-			return TryOpenVstEditorForStation(station, pluginIndex);
-		}
-		case base::SelectDepth::DEPTH_LOOPTAKE:
-		{
-			auto take = std::dynamic_pointer_cast<LoopTake>(hovering);
-			if (!take)
-				return false;
-
-			for (const auto& loop : take->GetLoops())
+			if (auto loop = std::dynamic_pointer_cast<Loop>(current))
 			{
 				if (TryOpenVstEditorForLoop(loop, pluginIndex))
 					return true;
+				continue;
 			}
 
-			return false;
+			if (auto take = std::dynamic_pointer_cast<LoopTake>(current))
+			{
+				for (const auto& loop : take->GetLoops())
+				{
+					if (TryOpenVstEditorForLoop(loop, pluginIndex))
+						return true;
+				}
+				continue;
+			}
+
+			if (auto station = std::dynamic_pointer_cast<Station>(current))
+			{
+				if (TryOpenVstEditorForStation(station, pluginIndex))
+					return true;
+			}
 		}
-		case base::SelectDepth::DEPTH_LOOP:
-		{
-			auto loop = std::dynamic_pointer_cast<Loop>(hovering);
-			return TryOpenVstEditorForLoop(loop, pluginIndex);
-		}
-		default:
-			return false;
-		}
+
+		return false;
 	}
 }

--- a/JammaLib/src/vst/VstEditorWindowManager.cpp
+++ b/JammaLib/src/vst/VstEditorWindowManager.cpp
@@ -45,6 +45,11 @@ namespace vst
 		return res;
 	}
 
+	void VstEditorWindowManager::SetLogging(base::LoggingConfig config) noexcept
+	{
+		_loggingConfig = std::move(config);
+	}
+
 	actions::ActionResult VstEditorWindowManager::HandleVstInsert(const std::wstring& pluginPath,
 		base::SelectDepth depth,
 		const std::shared_ptr<base::GuiElement>& hovering,
@@ -119,6 +124,12 @@ namespace vst
 		const std::vector<std::shared_ptr<Station>>& stations)
 	{
 		PruneClosedVstEditorWindows();
+
+		if (_loggingConfig.Ui == "verbose")
+		{
+			auto hoverStation = std::dynamic_pointer_cast<Station>(hovering);
+			std::cout << "VST editor open: hovering=" << (hoverStation ? "Station '" + hoverStation->Name() + "'" : hovering ? "non-station" : "null") << ", depth=" << static_cast<int>(depth) << std::endl;
+		}
 
 		if (TryOpenVstEditorForHover(hovering, depth, 0u))
 			return EatAction();

--- a/JammaLib/src/vst/VstEditorWindowManager.h
+++ b/JammaLib/src/vst/VstEditorWindowManager.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <mutex>
 #include "../actions/ActionResult.h"
+#include "../base/LoggingConfig.h"
 #include "../base/GuiElement.h"
 #include "../graphics/VstEditorWindow.h"
 #include "../engine/Station.h"
@@ -28,6 +29,7 @@ namespace vst
 		actions::ActionResult HandleVstEditorOpen(const std::shared_ptr<base::GuiElement>& hovering,
 			base::SelectDepth depth,
 			const std::vector<std::shared_ptr<engine::Station>>& stations);
+		void SetLogging(base::LoggingConfig config) noexcept;
 
 		bool OpenVstEditorForPlugin(const std::shared_ptr<IVstPlugin>& plugin);
 		bool TryOpenVstEditorForLoop(const std::shared_ptr<engine::Loop>& loop, size_t pluginIndex);
@@ -39,6 +41,7 @@ namespace vst
 		static actions::ActionResult EatAction();
 
 	private:
+		base::LoggingConfig _loggingConfig;
 		mutable std::mutex _vstEditorWindowsMutex;
 		std::vector<std::unique_ptr<graphics::VstEditorWindow>> _vstEditorWindows;
 	};


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the scene hover logic, logging configuration, and VST editor window management. The most significant changes include enhanced handling of hover state synchronization between 2D and 3D contexts, improvements to logging propagation, and a more flexible approach to opening VST editor windows based on UI context.

**Scene Hover Handling and Synchronization:**
- Refactored the hover update logic in `Scene` by renaming `ResolveDeferredHover` to `ApplyDeferredHoverUpdates`, and enhanced it to better synchronize hover state between deferred 2D hit-testing and the latest 3D picker result. Now, if a station is hovered in 2D, the hover state is promoted and selection/tweak state is updated accordingly. If no valid 3D hover exists, the current hover is cleared. [[1]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fL1233-R1238) [[2]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fR1260-R1306) [[3]](diffhunk://#diff-5be142e68be091bda49a45c0a39bc571bd4b00cc20d84bf0702f461c681938b3L222-R222) [[4]](diffhunk://#diff-6e0354039bb9e0bd5d4dd721a77587b41c57f41eba18c10a56d2419371607feeL483-R483)

**Logging Improvements:**
- Updated `Scene::SetLogging` to propagate the logging configuration to the window subsystem, ensuring consistent logging behavior across subsystems.
- Added logging configuration support to `VstEditorWindowManager`, including a new `SetLogging` method and a private member to store the configuration. Verbose logging now outputs detailed information when opening VST editors. [[1]](diffhunk://#diff-15ec032ccebef98ed38759ec274f0fb30375a36ddc0670bcf7e7721f6feec0edR48-R52) [[2]](diffhunk://#diff-765c33a8e35fa9a2a0c196ee6036c2276d4469b131c32aaf6afd4df58a5cb2d5R8) [[3]](diffhunk://#diff-765c33a8e35fa9a2a0c196ee6036c2276d4469b131c32aaf6afd4df58a5cb2d5R32) [[4]](diffhunk://#diff-765c33a8e35fa9a2a0c196ee6036c2276d4469b131c32aaf6afd4df58a5cb2d5R44) [[5]](diffhunk://#diff-15ec032ccebef98ed38759ec274f0fb30375a36ddc0670bcf7e7721f6feec0edR128-R133)

**VST Editor Window Management Enhancements:**
- Refactored the logic for opening VST editor windows: instead of relying strictly on select depth, the code now traverses up the UI element hierarchy, attempting to open editors for loops, loop takes, and stations as appropriate. This makes the UI more flexible and robust to context changes.

**3D Picker and Rendering Adjustments:**
- Improved the picker path handling in `Scene::SetHover3d` to recognize `0xFF` as a valid terminator for missing path segments, enhancing compatibility with picker path conventions.
- Adjusted `StationModel::Draw3d` so that only the used portion of the station ID vector is incremented, and ensured picker geometry is rendered unscaled by setting specific uniforms.

**General Refactoring and Code Quality:**
- Cleaned up hover logging and state update logic in `Scene::SetHover3d`, making the code easier to follow and less error-prone. [[1]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fL1039-R1042) [[2]](diffhunk://#diff-0b822f02eb26f9a8fbb7dba0a2975076d0897b03013ff6ae38ab281306e7615fL1050-R1054)

These changes collectively improve the robustness, maintainability, and user feedback of the hover and VST editor management systems.